### PR TITLE
fix: include symlinks in file scan so lstatSync guard catches them

### DIFF
--- a/src/core/ingest.ts
+++ b/src/core/ingest.ts
@@ -122,7 +122,7 @@ function scanMarkdownFiles(rootDir: string, currentDir: string = ''): string[] {
     const relativePath = currentDir ? `${currentDir}/${entry.name}` : entry.name;
     if (entry.isDirectory()) {
       results.push(...scanMarkdownFiles(rootDir, relativePath));
-    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+    } else if ((entry.isFile() || entry.isSymbolicLink()) && entry.name.endsWith('.md')) {
       results.push(relativePath);
     }
   }

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -278,13 +278,17 @@ describe('discoverCandidates', () => {
     expect(small?.skip).toBeUndefined();
   });
 
-  // Symlink test skipped on Windows — requires elevated privileges
-  // and behaves inconsistently across Windows versions
-  it.skipIf(process.platform === 'win32')('skips symbolic links', async () => {
+  it('skips symbolic links', async () => {
     writeSourceDoc('docs/real.md', '# Real\n\nContent.');
     const linkPath = path.join(sourceDir, 'docs', 'link.md');
     const targetPath = path.join(sourceDir, 'docs', 'real.md');
-    fs.symlinkSync(targetPath, linkPath);
+
+    try {
+      fs.symlinkSync(targetPath, linkPath);
+    } catch {
+      // Symlink creation may require privileges on some systems — skip test
+      return;
+    }
 
     const candidates = await discoverCandidates(sourceDir, {
       source: sourceDir,


### PR DESCRIPTION
On Linux, dirent.isFile() returns false for symlinks, so they were never discovered by scanMarkdownFiles and the lstatSync guard never ran. Now includes symlinks in the scan so the downstream guard properly skips them.

Fixes CI failure in ingest.test.ts:297 on Linux runners.

- scanMarkdownFiles now checks isSymbolicLink() in addition to isFile()
- Symlink test uses try/catch for cross-platform compat instead of platform skip
- 41 ingest tests pass