### PR TITLE
Rewrite README: 514 lines to 74 lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone https://github.com/vraspar/brain.git
 cd brain && npm install && npm run build && npm link
 ```
 
-Requires Node.js 18+ and git.
+Requires Node.js 20+ and git.
 
 ## Usage
 


### PR DESCRIPTION
Strip the README down to what belongs in a README. All detailed content already exists in docs/.

**Before:** 514 lines duplicating CLI reference, MCP tool tables, config schema, entry format, data layout, project structure, dependencies table.

**After:** 74 lines. One-sentence description, 2-line install, 9-command usage block, 8 feature bullets, MCP config snippet, docs links section.

Modeled after ripgrep/fzf/gh READMEs — short, scannable, links to detailed docs.

**What was removed (already in docs/):**
- Full CLI reference with all flags → docs/commands.md
- MCP tool parameter tables → docs/mcp-integration.md
- Config YAML schema and field table → docs/configuration.md
- Entry format and frontmatter reference → docs/configuration.md
- Data layout tree → docs/configuration.md
- Project structure tree → docs/architecture.md
- Dependencies table → package.json
- Mermaid architecture diagram → docs/architecture.md
- Planned features list → ROADMAP.md