### PR TITLE
Fix docs audit: list flags, Node version, command count

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js 18 or later
+- Node.js 20 or later
 - git
 - npm
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm run build
 npm link    # makes 'brain' available globally
 ```
 
-Requires Node.js 18+ and git.
+Requires Node.js 20+ and git.
 
 ## Quick start
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current (v0.3.0)
 
-- 16 CLI commands: `init`, `connect`, `push`, `digest`, `search`, `show`, `list`, `stats`, `retract`, `sync`, `serve`, `ingest`, `prune`, `restore`, `trail`
+- 15 CLI commands: `init`, `connect`, `push`, `digest`, `search`, `show`, `list`, `stats`, `retract`, `sync`, `serve`, `ingest`, `prune`, `restore`, `trail`
 - Repo ingest: `brain ingest` imports docs from remote repos or local directories with freshness scoring at import time
 - Freshness scoring: multiplicative formula (recency base, usage boost, volatility modifier) with Fresh/Aging/Stale labels
 - Knowledge pruning: `brain prune` archives stale entries to `_archive/`, reversible with `brain restore`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -326,16 +326,18 @@ To find entry IDs, use `brain search` or `brain list`.
 List all entries, optionally filtered.
 
 ```
-brain list [--type guide|skill] [--author <name>] [--tag <tag>] [--mine] [--unread]
+brain list [--type guide|skill] [--author <name>] [--tag <tag>...] [--mine] [--unread] [--stale] [--fresh]
 ```
 
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--type <type>` | No | Filter: `guide` or `skill`. |
 | `--author <name>` | No | Filter by author name (exact match). |
-| `--tag <tag>` | No | Filter by tag. |
+| `--tag <tag>` | No | Filter by tag. Repeatable (entries matching any tag are included). |
 | `--mine` | No | Show only your own entries. |
 | `--unread` | No | Show only entries you have not read. |
+| `--stale` | No | Show only stale entries (freshness score below threshold). |
+| `--fresh` | No | Show only fresh entries. |
 
 ### Examples
 
@@ -345,6 +347,8 @@ brain list --type skill        # only skills
 brain list --author alice      # only alice's entries
 brain list --mine --unread     # your unread entries
 brain list --tag docker        # entries tagged 'docker'
+brain list --stale             # stale entries needing review
+brain list --fresh             # healthy entries
 brain list --format json       # JSON array of entries
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide walks through installing Brain CLI, creating or joining a brain, and 
 
 ## Prerequisites
 
-- Node.js 18 or later
+- Node.js 20 or later
 - git configured with `user.name` (used as your author identity)
 
 ## Install


### PR DESCRIPTION
Fixes 3 findings from QA docs audit:

1. **P1**: docs/commands.md brain list missing \--stale\ and \--fresh\ flags, \--tag\ not shown as repeatable
2. **P1**: Node.js prereq was 18+ but CI dropped Node 18 (ba9896b) — updated to 20+ across README, getting-started.md, CONTRIBUTING.md
3. **P2**: ROADMAP.md said 16 commands but only 15 exist (brain join was removed)