### PR TITLE
Fix website: accuracy, version, remove marketing language

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -107,15 +107,15 @@ Top: K8s Patterns (12 reads, 4 unique)</div>
       <div class="cards-grid">
         <div class="card">
           <h3>Git as storage</h3>
-          <p>Entries are markdown in a git repo. No server. No database. No infrastructure to manage. Version history and access control are free.</p>
+          <p>Entries are markdown in a git repo. No server to run. No infrastructure to manage. Version history and access control come from git.</p>
         </div>
         <div class="card">
           <h3>FTS5 search</h3>
           <p>SQLite FTS5 with BM25 ranking, prefix matching, and contextual snippets. Sub-millisecond search. Works offline.</p>
         </div>
         <div class="card">
-          <h3>MCP-native</h3>
-          <p>Your AI agent already knows what your team knows. 5 tools and 2 resources exposed via Model Context Protocol. <code>brain serve</code> starts the server.</p>
+          <h3>MCP server</h3>
+          <p>5 tools and 2 resources exposed via Model Context Protocol. AI agents can search, read, and publish entries. <code>brain serve</code> starts the server.</p>
         </div>
         <div class="card">
           <h3>Repo ingest</h3>
@@ -132,7 +132,6 @@ Top: K8s Patterns (12 reads, 4 unique)</div>
       </div>
 
       <p class="section-punch">
-        <strong>Zero infrastructure. One command to start.</strong><br>
         <code>brain connect https://github.com/acme/brain-hub.git</code>
       </p>
     </div>
@@ -159,7 +158,7 @@ Top: K8s Patterns (12 reads, 4 unique)</div>
 
       <p class="agent-tools">5 tools: push_knowledge · search_knowledge · whats_new · get_entry · brain_stats<br>2 resources: brain://digest · brain://stats</p>
 
-      <p class="agent-desc">Your agent can search team knowledge, publish findings, and check what's new — without you asking it to.</p>
+      <p class="agent-desc">AI agents can search team knowledge, publish findings, and check what's new.</p>
 
       <p class="agent-clients">Claude · Copilot · Cursor · Windsurf</p>
     </div>
@@ -183,7 +182,7 @@ Top: K8s Patterns (12 reads, 4 unique)</div>
         <div><span class="prompt">$ </span><span class="command">brain connect &lt;url&gt;</span></div>
       </div>
 
-      <p class="prereqs">Requires Node.js 18+ and git.</p>
+      <p class="prereqs">Requires Node.js 20+ and git.</p>
     </div>
   </section>
 
@@ -235,7 +234,7 @@ Top: K8s Patterns (12 reads, 4 unique)</div>
 <!-- Footer -->
 <footer class="site-footer">
   <div class="container">
-    <div>brain v0.1.0 · MIT License</div>
+    <div>brain v0.3.0 · MIT License</div>
     <div class="footer-links">
       <a href="https://github.com/vraspar/brain">GitHub ↗</a>
       <a href="https://github.com/vraspar/brain/tree/main/docs">Docs ↗</a>


### PR DESCRIPTION
6 fixes for website/index.html:

**Inaccuracies:**
- Node.js 18+ → 20+ (CI dropped Node 18)
- Footer version v0.1.0 → v0.3.0
- 'No database' claim removed (there IS a SQLite database)

**Marketing language removed:**
- 'Your AI agent already knows what your team knows' → factual description
- 'Zero infrastructure. One command to start.' → removed
- 'without you asking it to' → removed
- 'MCP-native' → 'MCP server'
- 'access control are free' → 'access control come from git'