### PR TITLE
fix: polish website to match README tone and accuracy

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>brain — CLI-first knowledge sharing for dev teams</title>
-  <meta name="description" content="Share technical knowledge via git. Search with FTS5. Plug into AI agents via MCP.">
+  <meta name="description" content="A CLI for sharing knowledge across a dev team. Markdown in git, searchable via FTS5, accessible to AI agents through MCP.">
   <meta property="og:title" content="brain — CLI-first knowledge sharing for dev teams">
-  <meta property="og:description" content="Share technical knowledge via git. Search with FTS5. Plug into AI agents via MCP.">
+  <meta property="og:description" content="A CLI for sharing knowledge across a dev team. Markdown in git, searchable via FTS5, accessible to AI agents through MCP.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://vraspar.github.io/brain/">
   <meta name="twitter:card" content="summary_large_image">
@@ -25,14 +25,14 @@
   <div class="container">
     <div class="hero-wordmark">brain</div>
     <p class="hero-subtitle">
-      <span>CLI-first knowledge sharing for dev teams.</span><br>
-      Backed by git. Searchable with FTS5.<br>
-      Plugs into your AI agent via MCP.
+      <span>A CLI for sharing knowledge across a dev team.</span><br>
+      Markdown in git. Searchable via FTS5.<br>
+      Accessible to AI agents through MCP.
     </p>
 
     <div class="install-block">
-      <code><span class="prompt">$</span> git clone https://github.com/vraspar/brain.git</code>
-      <button class="copy-btn" data-copy="git clone https://github.com/vraspar/brain.git" aria-label="Copy to clipboard">
+      <code><span class="prompt">$</span> git clone https://github.com/vraspar/brain.git && cd brain && npm install && npm run build && npm link</code>
+      <button class="copy-btn" data-copy="git clone https://github.com/vraspar/brain.git && cd brain && npm install && npm run build && npm link" aria-label="Copy to clipboard">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
       </button>
     </div>
@@ -58,12 +58,10 @@
         <div>
           <div class="step-label">1. Create</div>
           <div class="terminal" aria-label="Terminal showing brain init command">
-            <div><span class="prompt">$ </span><span class="command">brain init --name "Acme Engineering" \</span></div>
-            <div><span class="command">    --remote https://github.com/acme/brain-hub.git</span></div>
+            <div><span class="prompt">$ </span><span class="command">brain init --name "My Team"</span></div>
             <div class="output" style="white-space:pre">
-✅ Brain "Acme Engineering" is ready!
+✅ Brain "My Team" is ready!
    Local:  ~/.brain/repo
-   Remote: https://github.com/acme/brain-hub.git
    Author: alice</div>
           </div>
         </div>
@@ -71,7 +69,7 @@
         <div>
           <div class="step-label">2. Share</div>
           <div class="terminal" aria-label="Terminal showing brain push command">
-            <div><span class="prompt">$ </span><span class="command">brain push ./docker-guide.md</span></div>
+            <div><span class="prompt">$ </span><span class="command">brain push ./guide.md</span></div>
             <div class="output" style="white-space:pre">
 ✅ Pushed: Docker Multi-Stage Builds
    Tags: docker (auto-detected)</div>
@@ -80,19 +78,17 @@
 
         <div class="step-full">
           <div class="step-label">3. Discover</div>
-          <div class="terminal" aria-label="Terminal showing brain digest command">
-            <div><span class="prompt">$ </span><span class="command">brain digest</span></div>
+          <div class="terminal" aria-label="Terminal showing brain search command">
+            <div><span class="prompt">$ </span><span class="command">brain search "kubernetes"</span></div>
             <div class="output" style="white-space:pre">
-New Entries (3)
-+------------------------+--------+-------+-------+
-| Title                  | Author | Type  | Reads |
-+------------------------+--------+-------+-------+
-| Docker Guide           | alice  | guide | 8     |
-| K8s Patterns           | bob    | skill | 12    |
-| CI Pipeline            | carol  | guide | 5     |
-+------------------------+--------+-------+-------+
-
-Top: K8s Patterns (12 reads, 4 unique)</div>
+Found 3 results:
++------------------------+--------+-------+-----------+
+| Title                  | Author | Type  | Tags      |
++------------------------+--------+-------+-----------+
+| K8s Deployment Guide   | bob    | guide | k8s       |
+| CI Pipeline            | carol  | guide | ci, k8s   |
+| Helm Chart Patterns    | alice  | skill | helm, k8s |
++------------------------+--------+-------+-----------+</div>
           </div>
         </div>
       </div>
@@ -158,7 +154,7 @@ Top: K8s Patterns (12 reads, 4 unique)</div>
 
       <p class="agent-tools">5 tools: push_knowledge · search_knowledge · whats_new · get_entry · brain_stats<br>2 resources: brain://digest · brain://stats</p>
 
-      <p class="agent-desc">AI agents can search team knowledge, publish findings, and check what's new.</p>
+      <p class="agent-desc">Your agent can search team knowledge, publish findings, and check what's new.</p>
 
       <p class="agent-clients">Claude · Copilot · Cursor · Windsurf</p>
     </div>
@@ -172,13 +168,12 @@ Top: K8s Patterns (12 reads, 4 unique)</div>
       <div class="terminal" aria-label="Installation and setup commands">
         <div><span class="comment"># Install</span></div>
         <div><span class="prompt">$ </span><span class="command">git clone https://github.com/vraspar/brain.git</span></div>
-        <div><span class="prompt">$ </span><span class="command">cd brain && npm install && npm run build</span></div>
-        <div><span class="prompt">$ </span><span class="command">npm link</span></div>
+        <div><span class="prompt">$ </span><span class="command">cd brain && npm install && npm run build && npm link</span></div>
         <div>&nbsp;</div>
-        <div><span class="comment"># Create a brain (first person)</span></div>
-        <div><span class="prompt">$ </span><span class="command">brain init --name "Acme Engineering"</span></div>
+        <div><span class="comment"># Create a brain</span></div>
+        <div><span class="prompt">$ </span><span class="command">brain init --name "My Team"</span></div>
         <div>&nbsp;</div>
-        <div><span class="comment"># Or join an existing one (teammates)</span></div>
+        <div><span class="comment"># Or join an existing one</span></div>
         <div><span class="prompt">$ </span><span class="command">brain connect &lt;url&gt;</span></div>
       </div>
 

--- a/website/terminal.js
+++ b/website/terminal.js
@@ -6,20 +6,27 @@
 
   var DEMO_SEQUENCE = [
     {
-      command: 'brain search "docker deployment"',
+      command: 'brain search "kubernetes"',
       output:
         'Found 3 results:\n' +
-        '+------------------------+--------+-------+---------------+\n' +
-        '| Title                  | Author | Type  | Tags          |\n' +
-        '+------------------------+--------+-------+---------------+\n' +
-        '| Docker Multi-Stage     | alice  | guide | docker        |\n' +
-        '| K8s Deployment Guide   | bob    | guide | k8s, docker   |\n' +
-        '| CI Pipeline Setup      | carol  | guide | ci, github    |\n' +
-        '+------------------------+--------+-------+---------------+',
+        '+------------------------+--------+-------+-----------+\n' +
+        '| Title                  | Author | Type  | Tags      |\n' +
+        '+------------------------+--------+-------+-----------+\n' +
+        '| K8s Deployment Guide   | bob    | guide | k8s       |\n' +
+        '| CI Pipeline            | carol  | guide | ci, k8s   |\n' +
+        '| Helm Chart Patterns    | alice  | skill | helm, k8s |\n' +
+        '+------------------------+--------+-------+-----------+',
       pauseAfter: 2500,
     },
     {
-      command: 'brain digest --since 7d',
+      command: 'brain push ./guide.md',
+      output:
+        '✅ Pushed: Docker Multi-Stage Builds\n' +
+        '   Tags: docker (auto-detected)',
+      pauseAfter: 2000,
+    },
+    {
+      command: 'brain digest',
       output:
         'New Entries (2)\n' +
         '+------------------------+--------+-------+-------+\n' +
@@ -27,20 +34,16 @@
         '+------------------------+--------+-------+-------+\n' +
         '| Docker Multi-Stage     | alice  | guide | 8     |\n' +
         '| React Testing Patterns | bob    | skill | 12    |\n' +
-        '+------------------------+--------+-------+-------+\n' +
-        '\n' +
-        'Top: React Testing Patterns (12 reads, 4 unique)',
+        '+------------------------+--------+-------+-------+',
       pauseAfter: 2500,
     },
     {
-      command: 'brain push --title "Helm Chart Patterns" --type guide --file ./helm.md',
+      command: 'brain trail kubernetes',
       output:
-        '✅ Pushed: Helm Chart Patterns\n' +
-        '   ID: helm-chart-patterns\n' +
-        '   Type: guide\n' +
-        '   File: guides/helm-chart-patterns.md\n' +
-        '   Tags: kubernetes, helm (auto-detected)',
-      pauseAfter: 3000,
+        'K8s Deployment Guide\n' +
+        '  → Helm Chart Patterns (tags: k8s)\n' +
+        '  → CI Pipeline (tags: k8s, ci)',
+      pauseAfter: 2500,
     },
   ];
 


### PR DESCRIPTION
Audit and fix website content against the rewritten 74-line README.

**Changes:**
- Hero subtitle matches README opening line exactly
- Install block shows full \clone && build && link\ command (not just clone)
- Quick start consolidated to 2-line install matching README
- How-it-works step 3 now shows \rain search\ (more impressive demo than digest)
- Init example simplified — no \--remote\ flag in basic usage
- Push uses simple \./guide.md\ syntax matching README
- Terminal animation updated with 4 commands: search, push, digest, trail
- Comments trimmed for conciseness
- Node.js 20+ confirmed correct

**Verified against:**
- README.md on main (74 lines)
- \rain --help\ output (15 commands)
- Actual CLI flag names