### PR TITLE
feat: highlight brain ingest on website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -60,14 +60,22 @@
           <div class="terminal" aria-label="Terminal showing brain init command">
             <div><span class="prompt">$ </span><span class="command">brain init --name "My Team"</span></div>
             <div class="output" style="white-space:pre">
-✅ Brain "My Team" is ready!
-   Local:  ~/.brain/repo
-   Author: alice</div>
+✅ Brain "My Team" is ready!</div>
           </div>
         </div>
 
         <div>
-          <div class="step-label">2. Share</div>
+          <div class="step-label">2. Import</div>
+          <div class="terminal" aria-label="Terminal showing brain ingest command">
+            <div><span class="prompt">$ </span><span class="command">brain ingest https://github.com/acme/docs.git</span></div>
+            <div class="output" style="white-space:pre">
+✅ Ingested 24 entries from acme/docs
+   💡 8% stale. Run 'brain prune --dry-run' to review.</div>
+          </div>
+        </div>
+
+        <div>
+          <div class="step-label">3. Share</div>
           <div class="terminal" aria-label="Terminal showing brain push command">
             <div><span class="prompt">$ </span><span class="command">brain push ./guide.md</span></div>
             <div class="output" style="white-space:pre">
@@ -77,7 +85,7 @@
         </div>
 
         <div class="step-full">
-          <div class="step-label">3. Discover</div>
+          <div class="step-label">4. Discover</div>
           <div class="terminal" aria-label="Terminal showing brain search command">
             <div><span class="prompt">$ </span><span class="command">brain search "kubernetes"</span></div>
             <div class="output" style="white-space:pre">

--- a/website/terminal.js
+++ b/website/terminal.js
@@ -6,6 +6,16 @@
 
   var DEMO_SEQUENCE = [
     {
+      command: 'brain ingest https://github.com/acme/docs.git',
+      output:
+        '🔍 Scanning https://github.com/acme/docs.git...\n' +
+        '   Found 32 documentation files\n' +
+        '\n' +
+        '✅ Ingested 24 entries from acme/docs\n' +
+        '   ⚠ 8 skipped (duplicate slug)',
+      pauseAfter: 2500,
+    },
+    {
       command: 'brain search "kubernetes"',
       output:
         'Found 3 results:\n' +
@@ -24,18 +34,6 @@
         '✅ Pushed: Docker Multi-Stage Builds\n' +
         '   Tags: docker (auto-detected)',
       pauseAfter: 2000,
-    },
-    {
-      command: 'brain digest',
-      output:
-        'New Entries (2)\n' +
-        '+------------------------+--------+-------+-------+\n' +
-        '| Title                  | Author | Type  | Reads |\n' +
-        '+------------------------+--------+-------+-------+\n' +
-        '| Docker Multi-Stage     | alice  | guide | 8     |\n' +
-        '| React Testing Patterns | bob    | skill | 12    |\n' +
-        '+------------------------+--------+-------+-------+',
-      pauseAfter: 2500,
     },
     {
       command: 'brain trail kubernetes',


### PR DESCRIPTION
Make ingest the star of the website — it's the killer feature that solves cold-start adoption.

**Changes:**
- How It Works is now 4 steps: Create → Import → Share → Discover
- Step 2 (Import) shows \rain ingest https://github.com/acme/docs.git\
- Terminal animation leads with ingest as the first demo command
- Replaced digest from animation (still visible in How It Works section)