### PR TITLE
feat: brain remote add, brain open, fix sync for local-only brains

### DIFF
--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { loadConfig } from '../core/config.js';
+import { createIndex, getDbPath, getEntryById } from '../core/index-db.js';
+
+/**
+ * Resolve the editor command. Checks $EDITOR, $VISUAL, then platform defaults.
+ */
+function resolveEditor(): string {
+  if (process.env['EDITOR']) return process.env['EDITOR'];
+  if (process.env['VISUAL']) return process.env['VISUAL'];
+
+  switch (process.platform) {
+    case 'darwin': return 'open';
+    case 'win32': return 'start';
+    default: return 'xdg-open';
+  }
+}
+
+export const openCommand = new Command('open')
+  .description('Open an entry file in your editor')
+  .argument('<entry-id>', 'Entry ID (slug) to open')
+  .action(async (entryId: string) => {
+    const format = openCommand.parent?.opts().format ?? 'text';
+
+    try {
+      const config = loadConfig();
+
+      const db = createIndex(getDbPath());
+      let filePath: string;
+      try {
+        const entry = getEntryById(db, entryId);
+        if (!entry) {
+          throw new Error(`Entry "${entryId}" not found. Run "brain list" to see available entries.`);
+        }
+        filePath = entry.filePath;
+      } finally {
+        db.close();
+      }
+
+      const fullPath = path.join(config.local, filePath);
+      if (!fs.existsSync(fullPath)) {
+        throw new Error(`Entry file not found at "${fullPath}". Run "brain sync" to update.`);
+      }
+
+      const editor = resolveEditor();
+
+      // Use execFileSync — no shell interpolation, prevents command injection
+      // via $EDITOR or filenames with special characters
+      try {
+        execFileSync(editor, [fullPath], { stdio: 'inherit' });
+      } catch {
+        throw new Error(
+          `Failed to open "${fullPath}" with "${editor}".\n` +
+          'Set $EDITOR or $VISUAL to your preferred editor.',
+        );
+      }
+
+      if (format === 'json') {
+        console.log(JSON.stringify({
+          status: 'opened',
+          entryId,
+          filePath: fullPath,
+          editor,
+        }, null, 2));
+      } else {
+        console.log(chalk.dim(`Opened ${filePath} in ${editor}`));
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (format === 'json') {
+        console.error(JSON.stringify({ error: message }));
+      } else {
+        console.error(chalk.red(`Error: ${message}`));
+      }
+      process.exitCode = 1;
+    }
+  });

--- a/src/commands/remote.ts
+++ b/src/commands/remote.ts
@@ -1,0 +1,69 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { loadConfig, saveConfig } from '../core/config.js';
+import { addRemote, pushToRemote } from '../utils/git.js';
+import { sanitizeUrl } from '../utils/url.js';
+
+export const remoteCommand = new Command('remote')
+  .description('Manage brain remote')
+  .argument('<action>', '"add" to set a remote URL')
+  .argument('<url>', 'Git remote URL')
+  .action(async (action: string, url: string) => {
+    const format = remoteCommand.parent?.opts().format ?? 'text';
+
+    try {
+      if (action !== 'add') {
+        throw new Error(`Unknown action "${action}". Use: brain remote add <url>`);
+      }
+
+      const config = loadConfig();
+
+      if (config.remote) {
+        throw new Error(
+          `Remote already configured: ${config.remote}\n` +
+          'Remove ~/.brain/config.yaml and re-run brain connect to change remotes.',
+        );
+      }
+
+      await addRemote(config.local, 'origin', url);
+
+      // Try initial push
+      let pushed = false;
+      try {
+        await pushToRemote(config.local);
+        pushed = true;
+      } catch {
+        // Push failure is non-fatal
+      }
+
+      // Update config with remote
+      const updatedConfig = {
+        ...config,
+        remote: sanitizeUrl(url),
+      };
+      saveConfig(updatedConfig);
+
+      if (format === 'json') {
+        console.log(JSON.stringify({
+          status: 'remote-added',
+          remote: sanitizeUrl(url),
+          pushed,
+        }, null, 2));
+      } else {
+        console.log(chalk.green(`✅ Remote added: ${sanitizeUrl(url)}`));
+        if (pushed) {
+          console.log(chalk.dim('   Pushed existing content to remote.'));
+        } else {
+          console.log(chalk.yellow('   ⚠ Could not push to remote. Run "brain sync" to retry.'));
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (format === 'json') {
+        console.error(JSON.stringify({ error: message }));
+      } else {
+        console.error(chalk.red(`Error: ${message}`));
+      }
+      process.exitCode = 1;
+    }
+  });

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -14,6 +14,34 @@ export const syncCommand = new Command('sync')
     try {
       const config = loadConfig();
 
+      // Check for local-only brain (no remote configured)
+      if (!config.remote) {
+        // Rebuild index locally without pulling
+        const entries = await scanEntries(config.local);
+        const db = createIndex(getDbPath());
+        try {
+          rebuildIndex(db, entries);
+          const statsMap = buildUsageStatsMap(config.local, '30d');
+          updateFreshnessScores(db, statsMap);
+        } finally {
+          db.close();
+        }
+
+        if (format === 'json') {
+          console.log(JSON.stringify({
+            status: 'synced-local',
+            totalEntries: entries.length,
+            message: 'No remote configured. Index rebuilt locally.',
+          }, null, 2));
+        } else {
+          console.log(chalk.green('✅ Index rebuilt locally.'));
+          console.log(chalk.dim(`   Total entries indexed: ${entries.length}`));
+          console.log('');
+          console.log(chalk.yellow('   ⚠ No remote configured. Add one with: brain remote add <url>'));
+        }
+        return;
+      }
+
       // Sync repo
       const result = await syncBrain(config);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ import { trailCommand } from './commands/trail.js';
 import { pruneCommand } from './commands/prune.js';
 import { ingestCommand } from './commands/ingest.js';
 import { restoreCommand } from './commands/restore.js';
+import { remoteCommand } from './commands/remote.js';
+import { openCommand } from './commands/open.js';
 
 const program = new Command();
 
@@ -41,5 +43,7 @@ program.addCommand(trailCommand);
 program.addCommand(pruneCommand);
 program.addCommand(ingestCommand);
 program.addCommand(restoreCommand);
+program.addCommand(remoteCommand);
+program.addCommand(openCommand);
 
 program.parse();

--- a/test/remote-open.test.ts
+++ b/test/remote-open.test.ts
@@ -1,0 +1,166 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { saveConfig, loadConfig } from '../src/core/config.js';
+import { createIndex, rebuildIndex, getDbPath, getEntryById } from '../src/core/index-db.js';
+import { scanEntries, createEntry, writeEntry } from '../src/core/entry.js';
+import type { BrainConfig } from '../src/types.js';
+
+let tempDir: string;
+let brainDir: string;
+let repoDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'brain-remote-open-test-'));
+  brainDir = path.join(tempDir, '.brain');
+  repoDir = path.join(tempDir, 'repo');
+  dbPath = path.join(brainDir, 'cache.db');
+
+  vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
+
+  fs.mkdirSync(path.join(repoDir, 'guides'), { recursive: true });
+  fs.mkdirSync(path.join(repoDir, 'skills'), { recursive: true });
+  fs.mkdirSync(brainDir, { recursive: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+// --- brain remote add ---
+
+describe('brain remote add', () => {
+  it('rejects add when remote already exists', () => {
+    const config: BrainConfig = {
+      remote: 'https://github.com/team/brain.git',
+      local: repoDir,
+      author: 'testuser',
+    };
+    saveConfig(config);
+
+    // The remote command would check config.remote and throw
+    const loaded = loadConfig();
+    expect(loaded.remote).toBeDefined();
+    // Simulating the check from remote.ts
+    expect(() => {
+      if (loaded.remote) {
+        throw new Error(`Remote already configured: ${loaded.remote}`);
+      }
+    }).toThrow('Remote already configured');
+  });
+
+  it('allows add when no remote configured', () => {
+    const config: BrainConfig = {
+      local: repoDir,
+      author: 'testuser',
+    };
+    saveConfig(config);
+
+    const loaded = loadConfig();
+    expect(loaded.remote).toBeUndefined();
+  });
+
+  it('saves remote URL to config after add', () => {
+    const config: BrainConfig = {
+      local: repoDir,
+      author: 'testuser',
+    };
+    saveConfig(config);
+
+    // Simulate what remote add does
+    const updated = { ...config, remote: 'https://github.com/team/brain.git' };
+    saveConfig(updated);
+
+    const loaded = loadConfig();
+    expect(loaded.remote).toBe('https://github.com/team/brain.git');
+  });
+});
+
+// --- brain open ---
+
+describe('brain open', () => {
+  it('resolves entry file path from ID', async () => {
+    const config: BrainConfig = {
+      local: repoDir,
+      author: 'testuser',
+    };
+    saveConfig(config);
+
+    const entry = createEntry({
+      title: 'Docker Guide',
+      type: 'guide',
+      content: 'How to use docker.',
+      author: 'alice',
+    });
+    await writeEntry(repoDir, entry);
+
+    const entries = await scanEntries(repoDir);
+    const db = createIndex(dbPath);
+    try {
+      rebuildIndex(db, entries);
+      const found = getEntryById(db, 'docker-guide');
+      expect(found).not.toBeNull();
+      expect(found!.filePath).toBe('guides/docker-guide.md');
+
+      const fullPath = path.join(repoDir, found!.filePath);
+      expect(fs.existsSync(fullPath)).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('returns null for non-existent entry', () => {
+    const db = createIndex(dbPath);
+    try {
+      const found = getEntryById(db, 'nonexistent');
+      expect(found).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+});
+
+// --- brain sync local-only ---
+
+describe('brain sync local-only', () => {
+  it('detects local-only brain (no remote)', () => {
+    const config: BrainConfig = {
+      local: repoDir,
+      author: 'testuser',
+    };
+    saveConfig(config);
+
+    const loaded = loadConfig();
+    expect(loaded.remote).toBeUndefined();
+  });
+
+  it('rebuilds index locally when no remote', async () => {
+    const config: BrainConfig = {
+      local: repoDir,
+      author: 'testuser',
+    };
+    saveConfig(config);
+
+    const entry = createEntry({
+      title: 'Local Guide',
+      type: 'guide',
+      content: 'Local-only content.',
+      author: 'testuser',
+    });
+    await writeEntry(repoDir, entry);
+
+    const entries = await scanEntries(repoDir);
+    const db = createIndex(dbPath);
+    try {
+      rebuildIndex(db, entries);
+      const found = getEntryById(db, 'local-guide');
+      expect(found).not.toBeNull();
+      expect(found!.title).toBe('Local Guide');
+    } finally {
+      db.close();
+    }
+  });
+});


### PR DESCRIPTION
Three small features:

**1. \rain remote add <url>\** — Add git remote to local-only brain, push existing content, save sanitized URL.

**2. \rain open <entry-id>\** — Open entry in editor. Uses \xecFileSync\ (no shell, no command injection). Falls back: \ → \ → platform default.

**3. Fix \rain sync\ for local-only brains** — Detects missing remote, rebuilds index locally, shows: 'No remote configured. Add one with: brain remote add <url>'

7 new tests. Build clean.