### PR TITLE
fix: register brain edit and brain status in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-25
+
+### Added
+
+- `brain edit <entry-id>` command for metadata editing (title, tags, type, summary) without opening the file
+- `brain edit` supports `--add-tag` and `--remove-tag` for incremental tag changes
+- `brain edit` handles type changes by moving files between `guides/` and `skills/`
+- `brain status` command showing health dashboard: entry counts, freshness distribution, storage sizes, sync state
+- `brain open <entry-id>` command to open entry files in `$EDITOR` / `$VISUAL` (uses `execFileSync`, no shell injection)
+- `brain remote add <url>` command to add a remote to local-only brains
+- `brain sources` command group for managing external source repositories (`list`, `sync`, `remove`)
+- Incremental source sync via persistent bare mirrors and `git fetch`
+- `get_recommendations` MCP tool for topic-based entry suggestions using FTS5 + tag overlap + freshness
+- `update_entry` MCP tool for partial field updates (title, tags, type, summary, content, status)
+- Source registry at `~/.brain/sources.json` for tracking ingested repos
+
 ## [0.3.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ brain push ./docs/*.md                       # batch import
 brain ingest https://github.com/team/repo    # import from another repo
 brain search "kubernetes"                    # full-text search
 brain digest                                 # what's new
+brain edit k8s-guide --add-tag helm          # update metadata
+brain open k8s-guide                         # open in $EDITOR
+brain status                                 # brain health dashboard
 brain trail kubernetes                       # follow connected entries
 brain prune --dry-run                        # find stale content
 ```
@@ -36,7 +39,7 @@ All commands support `--format json`. Run `brain <command> --help` for flags.
 - **Repo ingest** — import docs from external repos with freshness scoring
 - **Freshness** — entries scored Fresh/Aging/Stale; `brain prune` archives stale ones
 - **Knowledge trails** — auto-linked entries via tag overlap, title similarity, cross-references
-- **MCP server** — 5 tools + 2 resources, works with Claude, Copilot, Cursor, Windsurf
+- **MCP server** — 7 tools + 2 resources, works with Claude, Copilot, Cursor, Windsurf
 - **Read analytics** — per-entry read tracking across CLI and MCP
 - **Auto-detection** — title, type, and tags inferred from content on push
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -422,6 +422,91 @@ brain retract old-deployment-guide --format json
 
 ---
 
+## brain edit
+
+Edit an entry's metadata without opening the file. Updates frontmatter fields, commits, and pushes.
+
+```
+brain edit <entry-id> [--title <title>] [--tags <csv>] [--type <type>] [--add-tag <tag>...] [--remove-tag <tag>...] [--summary <text>]
+```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `<entry-id>` | Yes | Entry ID (slug) to edit. |
+| `--title <title>` | No | Set a new title. |
+| `--tags <csv>` | No | Replace all tags (comma-separated). |
+| `--type <type>` | No | Change type: `guide` or `skill`. Moves the file between directories. |
+| `--add-tag <tag>` | No | Add tag(s) without removing existing. Repeatable. |
+| `--remove-tag <tag>` | No | Remove specific tag(s). Repeatable. |
+| `--summary <text>` | No | Set or update the summary. |
+
+At least one edit flag is required. Updates the `updated` timestamp automatically.
+
+### Examples
+
+```bash
+brain edit k8s-guide --add-tag helm --add-tag argocd
+brain edit k8s-guide --title "K8s Deployment Runbook"
+brain edit k8s-guide --type skill               # moves from guides/ to skills/
+brain edit k8s-guide --remove-tag outdated
+brain edit k8s-guide --tags "k8s,helm,deploy"    # replace all tags
+```
+
+---
+
+## brain status
+
+Show a health dashboard for the brain.
+
+```
+brain status
+```
+
+No flags. Displays: hub name, local/remote paths, author, entry counts by type, freshness distribution (Fresh/Aging/Stale), archived entry count, ingested source repos, storage sizes, last sync/digest timestamps.
+
+---
+
+## brain open
+
+Open an entry file in your editor for direct content editing.
+
+```
+brain open <entry-id>
+```
+
+Uses `$EDITOR`, `$VISUAL`, or platform default (`open` on macOS, `xdg-open` on Linux). After editing, run `brain sync` to commit changes.
+
+---
+
+## brain remote add
+
+Add a git remote to a local-only brain.
+
+```
+brain remote add <url>
+```
+
+Sets the origin remote and attempts an initial push. Fails if a remote is already configured.
+
+---
+
+## brain sources
+
+Manage external source repositories for incremental sync.
+
+```
+brain sources                        # list registered sources
+brain sources list                   # same as above
+brain sources sync [name]            # sync from all or one source
+brain sources sync --dry-run         # preview changes
+brain sources sync --force           # overwrite local changes on conflict
+brain sources remove <name>          # unregister a source
+```
+
+Sources are registered automatically by `brain ingest` and tracked in `~/.brain/sources.json`. Sync uses `git fetch` against persistent bare mirrors for fast incremental updates.
+
+---
+
 ## brain ingest
 
 Import documentation from a git repository or local directory. Solves the cold-start problem by batch-importing existing docs.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -212,6 +212,29 @@ Follow a topic across related entries:
 brain trail kubernetes
 ```
 
+## Edit entries
+
+Update metadata without opening the file:
+
+```bash
+brain edit k8s-guide --add-tag helm
+brain edit k8s-guide --title "K8s Deployment Runbook"
+```
+
+Or open the file directly in your editor:
+
+```bash
+brain open k8s-guide
+```
+
+## Check brain health
+
+See entry counts, freshness distribution, and sync state:
+
+```bash
+brain status
+```
+
 ## Next steps
 
 - [Full CLI reference](commands.md) — all commands, flags, and edge cases

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -255,6 +255,44 @@ View read activity stats for a specific author.
 - **CI Pipeline Setup**: 12 reads, 5 unique readers
 ```
 
+### get_recommendations
+
+Get relevant entries for a topic using FTS5 search, tag overlap, and freshness scoring. Filters out archived entries.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `topic` | string | yes | — | Topic or keywords to get recommendations for |
+| `limit` | number | no | `5` | Maximum recommendations |
+
+**Example request:**
+
+```json
+{
+  "topic": "kubernetes deployment",
+  "limit": 3
+}
+```
+
+### update_entry
+
+Update an existing entry's fields. Commits changes automatically.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `id` | string | yes | — | Entry ID (slug) |
+| `title` | string | no | — | New title |
+| `tags` | string[] | no | — | Replace tags |
+| `type` | `"guide"` \| `"skill"` | no | — | Change type |
+| `summary` | string | no | — | Update summary |
+| `content` | string | no | — | Replace content body |
+| `status` | `"active"` \| `"stale"` \| `"archived"` | no | — | Set status |
+
+Only provided fields are updated. Updates the `updated` timestamp. Setting status to `"archived"` hides the entry from search, digest, and recommendations.
+
 ## Resources
 
 Resources provide ambient context that MCP clients can read without an explicit tool call. Both return `text/markdown` content.


### PR DESCRIPTION
Both commands were implemented but not wired into src/index.ts. Adds imports and addCommand() calls.