### PR TITLE
fix: exclude docs/ and _archive/ from ingest pipeline

### DIFF
--- a/src/core/ingest.ts
+++ b/src/core/ingest.ts
@@ -39,6 +39,7 @@ const META_FILES = new Set([
 const EXCLUDED_DIRS = new Set([
   'node_modules', '.git', '.github', '.vscode', 'dist', 'build',
   'coverage', '__pycache__', '.tox', 'vendor', 'target',
+  'docs', '_archive',
 ]);
 
 /**


### PR DESCRIPTION
Prevents project documentation from being ingested as brain entries.

**Root cause analysis:**
1. \docs/\ files in guides/ — caused by accidental ingest of project docs. Fix: add \docs\ and \_archive\ to EXCLUDED_DIRS.
2. \mpty\ entry — junk test entry, user should \rain retract empty\.
3. Rebuild does NOT lose ingested items — \scanEntries\ correctly reads guides/ and skills/ where ingested content is stored. No code change needed.