### PR TITLE
feat: interactive search selection

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,19 +1,59 @@
+import readline from 'node:readline/promises';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { loadConfig } from '../core/config.js';
 import { createIndex, getDbPath, searchEntriesWithSnippets } from '../core/index-db.js';
-import { formatSearchResults } from '../utils/output.js';
+import { getRelatedEntries } from '../core/links.js';
+import { recordReceipt } from '../core/receipts.js';
+import { formatEntry, formatSearchResults } from '../utils/output.js';
+import type { Entry } from '../types.js';
+
+/**
+ * Prompt the user to select a search result to view.
+ * Returns the selected entry or null if user quits.
+ */
+async function promptSelection(entries: Entry[]): Promise<Entry | null> {
+  if (!process.stdout.isTTY) return null;
+
+  console.log('');
+  for (let i = 0; i < entries.length; i++) {
+    console.log(chalk.dim(`  [${i + 1}] `) + chalk.cyan(entries[i].id) + chalk.dim(` — ${entries[i].title}`));
+  }
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    const answer = await rl.question(`\n${chalk.cyan('?')} Show entry (1-${entries.length}, or q to quit): `);
+    const trimmed = answer.trim().toLowerCase();
+
+    if (trimmed === 'q' || trimmed === '') return null;
+
+    const index = parseInt(trimmed, 10);
+    if (isNaN(index) || index < 1 || index > entries.length) {
+      console.log(chalk.dim('  Invalid selection.'));
+      return null;
+    }
+
+    return entries[index - 1];
+  } finally {
+    rl.close();
+  }
+}
 
 export const searchCommand = new Command('search')
   .description('Search the team brain for entries')
   .argument('<query>', 'Search query (full-text search)')
   .option('--limit <n>', 'Maximum results to return', '20')
   .option('--no-preview', 'Hide content preview snippets')
-  .action(async (query: string, options: { limit: string; preview: boolean }) => {
+  .option('--no-interactive', 'Skip the selection prompt')
+  .action(async (query: string, options: { limit: string; preview: boolean; interactive: boolean }) => {
     const format = searchCommand.parent?.opts().format ?? 'text';
 
     try {
-      loadConfig(); // validate brain is initialized
+      const config = loadConfig();
       const db = createIndex(getDbPath());
 
       try {
@@ -30,6 +70,25 @@ export const searchCommand = new Command('search')
           : undefined;
 
         console.log(formatSearchResults(entries, { format, snippets }));
+
+        // Interactive selection (text mode only, TTY only)
+        if (format !== 'json' && options.interactive && entries.length > 0) {
+          const selected = await promptSelection(entries);
+          if (selected) {
+            await recordReceipt(config.local, selected.id, config.author, 'cli');
+            console.log('');
+            console.log(formatEntry(selected));
+
+            const related = getRelatedEntries(db, selected.id, 5);
+            if (related.length > 0) {
+              console.log('');
+              console.log(chalk.dim('📎 Related entries:'));
+              for (const { entry: rel, reason } of related) {
+                console.log(chalk.dim(`   • ${rel.id} — ${reason}`));
+              }
+            }
+          }
+        }
       } finally {
         db.close();
       }

--- a/test/search-interactive.test.ts
+++ b/test/search-interactive.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createIndex, getDbPath, rebuildIndex, searchEntriesWithSnippets } from '../src/core/index-db.js';
+import { scanEntries, createEntry, writeEntry } from '../src/core/entry.js';
+import { saveConfig } from '../src/core/config.js';
+import type { BrainConfig } from '../src/types.js';
+
+let tempDir: string;
+let brainDir: string;
+let repoDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'brain-search-test-'));
+  brainDir = path.join(tempDir, '.brain');
+  repoDir = path.join(tempDir, 'repo');
+  dbPath = path.join(brainDir, 'cache.db');
+
+  vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
+
+  fs.mkdirSync(path.join(repoDir, 'guides'), { recursive: true });
+  fs.mkdirSync(path.join(repoDir, 'skills'), { recursive: true });
+  fs.mkdirSync(brainDir, { recursive: true });
+
+  const config: BrainConfig = {
+    remote: 'https://github.com/team/brain.git',
+    local: repoDir,
+    author: 'testuser',
+    lastSync: new Date().toISOString(),
+  };
+  saveConfig(config);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('search with interactive selection', () => {
+  it('search returns entries with IDs for selection', async () => {
+    const entries = [
+      createEntry({ title: 'K8s Deployment Guide', type: 'guide', content: 'Deploy on kubernetes k8s cluster.', author: 'alice', tags: ['k8s'] }),
+      createEntry({ title: 'Helm Chart Patterns', type: 'skill', content: 'Helm kubernetes patterns.', author: 'bob', tags: ['helm', 'k8s'] }),
+    ];
+
+    for (const entry of entries) {
+      await writeEntry(repoDir, entry);
+    }
+
+    const db = createIndex(dbPath);
+    try {
+      const scanned = await scanEntries(repoDir);
+      rebuildIndex(db, scanned);
+
+      const results = searchEntriesWithSnippets(db, 'kubernetes', 20);
+      expect(results.length).toBeGreaterThanOrEqual(1);
+
+      // Verify entries have IDs that can be used for selection
+      for (const result of results) {
+        expect(result.entry.id).toBeTruthy();
+        expect(result.entry.title).toBeTruthy();
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  it('search results include entry IDs usable for brain show', async () => {
+    const entry = createEntry({
+      title: 'Docker Multi-Stage Builds',
+      type: 'guide',
+      content: 'How to use docker multi-stage builds for smaller images.',
+      author: 'alice',
+      tags: ['docker'],
+    });
+    await writeEntry(repoDir, entry);
+
+    const db = createIndex(dbPath);
+    try {
+      const scanned = await scanEntries(repoDir);
+      rebuildIndex(db, scanned);
+
+      const results = searchEntriesWithSnippets(db, 'docker', 20);
+      expect(results).toHaveLength(1);
+      expect(results[0].entry.id).toBe('docker-multi-stage-builds');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('empty search returns no results', async () => {
+    const entry = createEntry({
+      title: 'Docker Guide',
+      type: 'guide',
+      content: 'Docker stuff.',
+      author: 'alice',
+    });
+    await writeEntry(repoDir, entry);
+
+    const db = createIndex(dbPath);
+    try {
+      const scanned = await scanEntries(repoDir);
+      rebuildIndex(db, scanned);
+
+      const results = searchEntriesWithSnippets(db, 'xyznonexistent', 20);
+      expect(results).toHaveLength(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('search command has --no-interactive option', async () => {
+    const { searchCommand } = await import('../src/commands/search.js');
+    const opts = searchCommand.options.map((o: { long: string }) => o.long);
+    expect(opts).toContain('--no-interactive');
+  });
+});


### PR DESCRIPTION
After \rain search\ shows results, prompts user to select an entry to view:

\\\
\$ brain search kubernetes
Found 3 results:
  [1] k8s-deployment-guide — Kubernetes Deployment Guide
  [2] helm-charts — Helm Chart Patterns
  [3] ci-pipeline — CI Pipeline Setup

Show entry (1-3, or q to quit): 2
\\\

Displays full entry with related entries, records read receipt.

**Guards:**
- Text mode only (not \--format json\)
- TTY only (\process.stdout.isTTY\)
- \--no-interactive\ flag to disable

Uses \
ode:readline/promises\ (same as brain init wizard). 4 new tests.