### PR TITLE
fix: complete sync pipeline - content hash + source registration

### DIFF
--- a/src/core/entry.ts
+++ b/src/core/entry.ts
@@ -55,6 +55,8 @@ export function parseEntry(filePath: string, content: string): Entry {
     related_tools: asStringArray(data['related_tools']),
     summary: data['summary'] ? String(data['summary']) : undefined,
     source_repo: data['source_repo'] ? String(data['source_repo']) : undefined,
+    source_path: data['source_path'] ? String(data['source_path']) : undefined,
+    source_content_hash: data['source_content_hash'] ? String(data['source_content_hash']) : undefined,
   };
 }
 
@@ -81,6 +83,8 @@ export function serializeEntry(entry: Omit<Entry, 'id' | 'filePath'>): string {
   if (entry.related_repos?.length) frontmatter['related_repos'] = entry.related_repos;
   if (entry.related_tools?.length) frontmatter['related_tools'] = entry.related_tools;
   if (entry.source_repo) frontmatter['source_repo'] = entry.source_repo;
+  if (entry.source_path) frontmatter['source_path'] = entry.source_path;
+  if (entry.source_content_hash) frontmatter['source_content_hash'] = entry.source_content_hash;
 
   return matter.stringify(entry.content, frontmatter);
 }

--- a/src/core/ingest.ts
+++ b/src/core/ingest.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import crypto from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { cloneForIngest, cloneRepo, getBatchFileModifiedDates, validateUrl } from '../utils/git.js';
@@ -306,6 +307,8 @@ export async function importCandidates(
       filePath: `${dirName}/${slug}.md`,
       status,
       source_repo: repoName,
+      source_path: candidate.sourcePath,
+      source_content_hash: crypto.createHash('sha256').update(candidate.content).digest('hex'),
     };
 
     // Set dates from source if available

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -396,8 +396,8 @@ function registerUpdateEntry(server: McpServer, context: BrainMcpContext): void 
 
         // Clear source_content_hash if content was modified, so brain sources sync
         // won't overwrite agent edits (treats entry as "locally modified")
-        if (content !== undefined && 'source_content_hash' in updated) {
-          (updated as Record<string, unknown>)['source_content_hash'] = undefined;
+        if (content !== undefined && updated.source_content_hash) {
+          updated.source_content_hash = undefined;
         }
 
         // Write updated entry to disk

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export interface EntryFrontmatter {
   related_tools?: string[];
   summary?: string;
   source_repo?: string;
+  source_path?: string;
+  source_content_hash?: string;
   archived_at?: string; // ISO 8601
   archived_reason?: string;
 }


### PR DESCRIPTION
Completes the multi-repo sync pipeline:

1. **source_content_hash stored during ingest** — SHA256 hash of content at ingest time, enabling conflict detection during sync
2. **source_path stored during ingest** — original file path in source repo, enabling sync to find matching entries
3. **Entry type updated** — source_path and source_content_hash added to EntryFrontmatter
4. **Serialization updated** — parseEntry reads and serializeEntry writes the new fields
5. **MCP tools fix** — update_entry properly clears source_content_hash on content edit

Full verified flow: ingest → stores hash + path → sources list → sources sync → hash comparison detects local edits → skips edited entries.