### PR TITLE
docs: full refresh — README, getting-started, CHANGELOG, website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-03-26
+
+### Added
+
+- Interactive search selection — `brain search` prompts to view a result inline
+- `--no-interactive` flag to disable the selection prompt
+- `--shallow` flag for `brain ingest` (fastest clone, no freshness dating)
+
+### Changed
+
+- Ingest uses partial clone (`--filter=blob:none`) by default — 10x faster on large repos
+- Batch git log replaces per-file calls — single git process for all file dates
+- `brain list` and `brain search` output includes entry ID column
+
+### Fixed
+
+- Slug collisions during ingest: duplicate titles get `-2`, `-3` suffix
+- `brain sync` on local-only brains rebuilds index locally with friendly message
+- Removed stale `brain join` reference from getting-started docs
+
 ## [0.4.0] - 2026-03-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,13 +21,20 @@ brain connect <url>                          # or join an existing one
 brain push ./guide.md                        # publish an entry
 brain push ./docs/*.md                       # batch import
 brain ingest https://github.com/team/repo    # import from another repo
-brain search "kubernetes"                    # full-text search
+brain search "kubernetes"                    # full-text search (interactive)
+brain show k8s-guide                         # view a full entry
+brain list                                   # list all entries
+brain list --stale                           # find stale entries
 brain digest                                 # what's new
 brain edit k8s-guide --add-tag helm          # update metadata
 brain open k8s-guide                         # open in $EDITOR
-brain status                                 # brain health dashboard
 brain trail kubernetes                       # follow connected entries
+brain stats                                  # read activity for your entries
 brain prune --dry-run                        # find stale content
+brain retract k8s-guide                      # remove an entry
+brain sync                                   # pull latest + rebuild index
+brain remote add <url>                       # add remote to local brain
+brain status                                 # brain health dashboard
 ```
 
 All commands support `--format json`. Run `brain <command> --help` for flags.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,8 +84,6 @@ Output:
    Try: brain digest
 ```
 
-`brain join <url>` also works as a hidden alias for `brain connect` (not shown in `--help`).
-
 ## Push your first entry
 
 Write a markdown file with your knowledge, then push it:

--- a/website/index.html
+++ b/website/index.html
@@ -133,6 +133,14 @@ Found 3 results:
           <h3>Knowledge trails</h3>
           <p>Auto-computed links between entries. <code>brain trail &lt;topic&gt;</code> follows connections across your team's knowledge.</p>
         </div>
+        <div class="card">
+          <h3>Interactive search</h3>
+          <p>Search results are numbered. Pick one to read it inline. <code>brain search "kubernetes"</code> then select. Records a read receipt.</p>
+        </div>
+        <div class="card">
+          <h3>21 commands</h3>
+          <p>push, search, list, show, digest, edit, open, ingest, prune, restore, trail, status, and more. All support <code>--format json</code>.</p>
+        </div>
       </div>
 
       <p class="section-punch">
@@ -237,7 +245,7 @@ Found 3 results:
 <!-- Footer -->
 <footer class="site-footer">
   <div class="container">
-    <div>brain v0.4.0 · MIT License</div>
+    <div>brain v0.4.1 · MIT License</div>
     <div class="footer-links">
       <a href="https://github.com/vraspar/brain">GitHub ↗</a>
       <a href="https://github.com/vraspar/brain/tree/main/docs">Docs ↗</a>


### PR DESCRIPTION
Full docs refresh across 4 files.

**README.md:** Usage expanded from 12 to 20 commands.
**getting-started.md:** Removed stale brain join reference.
**CHANGELOG.md:** Added v0.4.1 section.
**website/index.html:** Added 2 feature cards, version to v0.4.1.

Docs consistency check passes.