### PR TITLE
fix: sync gaps - source columns in index, rebuild after sync, freshness on ingest

### DIFF
--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -3,9 +3,10 @@ import chalk from 'chalk';
 import { loadConfig } from '../core/config.js';
 import { runIngest, extractRepoName } from '../core/ingest.js';
 import { scanEntries } from '../core/entry.js';
-import { createIndex, rebuildIndex, getDbPath } from '../core/index-db.js';
+import { createIndex, rebuildIndex, getDbPath, updateFreshnessScores } from '../core/index-db.js';
 import { commitAndPush } from '../utils/git.js';
 import { upsertSource } from '../core/sources.js';
+import { buildUsageStatsMap } from '../core/freshness-stats.js';
 import type { EntryType, IngestCandidate } from '../types.js';
 
 function freshnessIcon(freshness: string): string {
@@ -130,6 +131,10 @@ export const ingestCommand = new Command('ingest')
           const entries = await scanEntries(config.local);
           rebuildIndex(db, entries);
 
+          // Compute freshness scores for ingested entries
+          const statsMap = buildUsageStatsMap(config.local, '30d');
+          updateFreshnessScores(db, statsMap);
+
           const entryFiles = entries
             .filter(e => e.source_repo === repoName)
             .map(e => e.filePath);
@@ -145,6 +150,10 @@ export const ingestCommand = new Command('ingest')
           // Local-only: rebuild index
           const entries = await scanEntries(config.local);
           rebuildIndex(db, entries);
+
+          // Compute freshness scores
+          const statsMap = buildUsageStatsMap(config.local, '30d');
+          updateFreshnessScores(db, statsMap);
         }
 
         // Register source for future sync

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -4,7 +4,9 @@ import Table from 'cli-table3';
 import { loadConfig } from '../core/config.js';
 import { loadSources, removeSource } from '../core/sources.js';
 import { syncSource } from '../core/source-sync.js';
-import { createIndex, getDbPath } from '../core/index-db.js';
+import { createIndex, getDbPath, rebuildIndex, updateFreshnessScores } from '../core/index-db.js';
+import { scanEntries } from '../core/entry.js';
+import { buildUsageStatsMap } from '../core/freshness-stats.js';
 
 export const sourcesCommand = new Command('sources')
   .description('Manage external source repositories')
@@ -88,6 +90,14 @@ sourcesCommand
 
         if (format === 'json') {
           console.log(JSON.stringify(results, null, 2));
+        }
+
+        // Rebuild index after sync to pick up new/updated/deleted entries
+        if (!options.dryRun) {
+          const entries = await scanEntries(config.local);
+          rebuildIndex(db, entries);
+          const statsMap = buildUsageStatsMap(config.local, '30d');
+          updateFreshnessScores(db, statsMap);
         }
       } finally {
         db.close();

--- a/src/core/index-db.ts
+++ b/src/core/index-db.ts
@@ -108,8 +108,8 @@ export function createIndex(dbPath: string): Database.Database {
  */
 export function rebuildIndex(db: Database.Database, entries: Entry[]): void {
   const insertEntry = db.prepare(`
-    INSERT OR REPLACE INTO entries (id, title, type, author, created_at, updated_at, tags, status, related_repos, related_tools, summary, content, file_path)
-    VALUES (@id, @title, @type, @author, @created_at, @updated_at, @tags, @status, @related_repos, @related_tools, @summary, @content, @file_path)
+    INSERT OR REPLACE INTO entries (id, title, type, author, created_at, updated_at, tags, status, related_repos, related_tools, summary, content, file_path, source_repo, source_path, source_content_hash)
+    VALUES (@id, @title, @type, @author, @created_at, @updated_at, @tags, @status, @related_repos, @related_tools, @summary, @content, @file_path, @source_repo, @source_path, @source_content_hash)
   `);
 
   const transaction = db.transaction((entryList: Entry[]) => {
@@ -132,6 +132,9 @@ export function rebuildIndex(db: Database.Database, entries: Entry[]): void {
         summary: entry.summary ?? null,
         content: entry.content,
         file_path: entry.filePath,
+        source_repo: entry.source_repo ?? null,
+        source_path: entry.source_path ?? null,
+        source_content_hash: entry.source_content_hash ?? null,
       });
     }
   });


### PR DESCRIPTION
Fixes 3 sync gaps from QA v2:

1. **rebuildIndex loses source tracking** — INSERT now includes source_repo, source_path, source_content_hash. Previously these were dropped on every rebuild, breaking findEntryBySourcePath used by sync's M/D detection.

2. **No rebuildIndex after sync** — brain sources sync now calls rebuildIndex + updateFreshnessScores. New/updated/deleted entries appear in search/list immediately.

3. **No freshness on ingest** — brain ingest now calls updateFreshnessScores. list --fresh/--stale works right after import.

Build clean.