### PR TITLE
fix: serve startup message and table title truncation

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -5,6 +5,8 @@ export const serveCommand = new Command('serve')
   .description('Start the Brain MCP server (stdio transport)')
   .action(async () => {
     try {
+      console.error('🧠 Brain MCP server running on stdio...');
+      console.error('   Press Ctrl+C to stop.\n');
       await startServer();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -8,6 +8,13 @@ export interface FormatOptions {
   format?: 'text' | 'json';
 }
 
+const MAX_TITLE_LENGTH = 40;
+
+function truncateTitle(title: string, maxLength = MAX_TITLE_LENGTH): string {
+  if (title.length <= maxLength) return title;
+  return title.slice(0, maxLength - 3) + '...';
+}
+
 export function formatEntry(entry: Entry, options: FormatOptions = {}): string {
   if (options.format === 'json') {
     return JSON.stringify(entry, null, 2);
@@ -75,7 +82,7 @@ function buildDigestTable(entries: DigestEntry[]): string {
 
   for (const entry of entries) {
     table.push([
-      entry.title,
+      truncateTitle(entry.title),
       entry.author,
       entry.type,
       entry.tags.slice(0, 3).join(', '),
@@ -119,7 +126,7 @@ export function formatStats(stats: StatsResult[], options: FormatOptions = {}): 
   });
 
   for (const stat of stats) {
-    table.push([stat.title, stat.accessCount.toString(), stat.uniqueReaders.toString(), stat.period]);
+    table.push([truncateTitle(stat.title), stat.accessCount.toString(), stat.uniqueReaders.toString(), stat.period]);
   }
 
   return table.toString();
@@ -176,7 +183,7 @@ export function formatSearchResults(
       const cleanSnippet = snippet.replace(/[«»]/g, '').slice(0, 60);
       table.push([
         chalk.dim(entry.id),
-        entry.title,
+        truncateTitle(entry.title),
         entry.author,
         entry.type,
         entry.tags.slice(0, 3).join(', '),
@@ -186,7 +193,7 @@ export function formatSearchResults(
       const label = options.freshness!.get(entry.id);
       table.push([
         chalk.dim(entry.id),
-        entry.title,
+        truncateTitle(entry.title),
         entry.author,
         entry.type,
         label ? freshnessIndicator(label) : statusColor(entry.status),
@@ -195,7 +202,7 @@ export function formatSearchResults(
     } else {
       table.push([
         chalk.dim(entry.id),
-        entry.title,
+        truncateTitle(entry.title),
         entry.author,
         entry.type,
         entry.tags.slice(0, 3).join(', '),

--- a/test/table-truncation.test.ts
+++ b/test/table-truncation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { DigestEntry, Entry, StatsResult } from '../src/types.js';
+import {
+  formatDigest,
+  formatSearchResults,
+  formatStats,
+} from '../src/utils/output.js';
+
+function makeEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    id: 'test-entry',
+    title: 'Test Entry',
+    author: 'alice',
+    created: '2026-03-01T00:00:00Z',
+    updated: '2026-03-20T00:00:00Z',
+    tags: ['testing'],
+    type: 'guide',
+    status: 'active',
+    content: 'Body content.',
+    filePath: 'guides/test-entry.md',
+    ...overrides,
+  };
+}
+
+describe('table title truncation', () => {
+  const longTitle = 'A Very Long Title That Definitely Exceeds The Forty Character Limit For Tables';
+
+  it('truncates long titles in search results', () => {
+    const entries = [makeEntry({ title: longTitle })];
+    const output = formatSearchResults(entries);
+    // Should contain truncated version, not full title
+    expect(output).not.toContain(longTitle);
+    expect(output).toContain('...');
+    // First 37 chars should still be present
+    expect(output).toContain(longTitle.slice(0, 37));
+  });
+
+  it('does not truncate short titles in search results', () => {
+    const shortTitle = 'Short Title';
+    const entries = [makeEntry({ title: shortTitle })];
+    const output = formatSearchResults(entries);
+    expect(output).toContain(shortTitle);
+    expect(output).not.toContain('Short Title...');
+  });
+
+  it('truncates long titles in digest table', () => {
+    const digestEntry: DigestEntry = {
+      ...makeEntry({ title: longTitle }),
+      isNew: true,
+      accessCount: 5,
+      uniqueReaders: 3,
+    };
+    const output = formatDigest([digestEntry]);
+    expect(output).not.toContain(longTitle);
+    expect(output).toContain('...');
+  });
+
+  it('truncates long titles in stats table', () => {
+    const stats: StatsResult[] = [{
+      entryId: 'test',
+      title: longTitle,
+      accessCount: 10,
+      uniqueReaders: 5,
+      period: '7d',
+    }];
+    const output = formatStats(stats);
+    expect(output).not.toContain(longTitle);
+    expect(output).toContain('...');
+  });
+
+  it('handles title exactly at max length', () => {
+    const exact40 = 'A'.repeat(40);
+    const entries = [makeEntry({ title: exact40 })];
+    const output = formatSearchResults(entries);
+    expect(output).toContain(exact40);
+    // Should NOT be truncated
+    expect(output).not.toContain(exact40 + '...');
+  });
+
+  it('handles title one char over max length', () => {
+    const over41 = 'B'.repeat(41);
+    const entries = [makeEntry({ title: over41 })];
+    const output = formatSearchResults(entries);
+    expect(output).not.toContain(over41);
+    expect(output).toContain('...');
+  });
+
+  it('does not truncate titles in JSON output', () => {
+    const entries = [makeEntry({ title: longTitle })];
+    const output = formatSearchResults(entries, { format: 'json' });
+    const parsed = JSON.parse(output);
+    // JSON should have the full title
+    expect(parsed[0].title).toBe(longTitle);
+  });
+});


### PR DESCRIPTION
1. serve: prints startup message to stderr so users know it started. 2. tables: truncates titles to 40 chars in all table outputs. 7 new tests.