### PR TITLE
fix: wire resolveEntryId into show/edit/open/retract

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { loadConfig } from '../core/config.js';
-import { createIndex, getDbPath, getEntryById, rebuildIndex } from '../core/index-db.js';
+import { createIndex, getDbPath, resolveEntryId, rebuildIndex } from '../core/index-db.js';
 import { parseEntry, serializeEntry, scanEntries } from '../core/entry.js';
 import { commitAndPush } from '../utils/git.js';
 import type { EntryType } from '../types.js';
@@ -35,15 +35,9 @@ export const editCommand = new Command('edit')
 
       let entry;
       try {
-        entry = getEntryById(db, entryId);
+        ({ entry } = resolveEntryId(db, entryId));
       } finally {
         db.close();
-      }
-
-      if (!entry) {
-        throw new Error(
-          `Entry "${entryId}" not found. Run "brain search" to find entries, or "brain list" to see all.`,
-        );
       }
 
       // Check that at least one edit option was provided

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { loadConfig } from '../core/config.js';
-import { createIndex, getDbPath, getEntryById } from '../core/index-db.js';
+import { createIndex, getDbPath, resolveEntryId } from '../core/index-db.js';
 
 /**
  * Resolve the editor command. Checks $EDITOR, $VISUAL, then platform defaults.
@@ -32,10 +32,7 @@ export const openCommand = new Command('open')
       const db = createIndex(getDbPath());
       let filePath: string;
       try {
-        const entry = getEntryById(db, entryId);
-        if (!entry) {
-          throw new Error(`Entry "${entryId}" not found. Run "brain list" to see available entries.`);
-        }
+        const { entry } = resolveEntryId(db, entryId);
         filePath = entry.filePath;
       } finally {
         db.close();

--- a/src/commands/retract.ts
+++ b/src/commands/retract.ts
@@ -5,7 +5,7 @@ import matter from 'gray-matter';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { loadConfig } from '../core/config.js';
-import { createIndex, getDbPath, getEntryById, rebuildIndex } from '../core/index-db.js';
+import { createIndex, getDbPath, resolveEntryId, rebuildIndex } from '../core/index-db.js';
 import { scanEntries } from '../core/entry.js';
 import { commitAndPush } from '../utils/git.js';
 
@@ -38,15 +38,9 @@ export const retractCommand = new Command('retract')
 
       let entry;
       try {
-        entry = getEntryById(db, entryId);
+        ({ entry } = resolveEntryId(db, entryId));
       } finally {
         db.close();
-      }
-
-      if (!entry) {
-        throw new Error(
-          `Entry "${entryId}" not found. Run "brain search" to find entries, or "brain list" to see all.`,
-        );
       }
 
       // Confirm unless --force

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { loadConfig } from '../core/config.js';
-import { createIndex, getDbPath, getEntryById } from '../core/index-db.js';
+import { createIndex, getDbPath, resolveEntryId } from '../core/index-db.js';
 import { getRelatedEntries } from '../core/links.js';
 import { recordReceipt } from '../core/receipts.js';
 import { formatEntry } from '../utils/output.js';
@@ -17,13 +17,7 @@ export const showCommand = new Command('show')
       const db = createIndex(getDbPath());
 
       try {
-        const entry = getEntryById(db, entryId);
-
-        if (!entry) {
-          throw new Error(
-            `Entry "${entryId}" not found. Run "brain search" to find entries, or "brain list" to see all.`,
-          );
-        }
+        const { entry } = resolveEntryId(db, entryId);
 
         // Record a read receipt
         await recordReceipt(config.local, entry.id, config.author, 'cli');


### PR DESCRIPTION
Commands now accept partial IDs: brain show docker resolves to docker-multi-stage-builds. Exact → prefix → contains matching with ambiguity suggestions.