### PR TITLE
docs: update install to npm install -g @vraspar/brain@alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,17 @@ A CLI for sharing knowledge across a dev team. Entries are markdown in a git rep
 ## Install
 
 ```
-git clone https://github.com/vraspar/brain.git
-cd brain && npm install && npm run build && npm link
+npm install -g @vraspar/brain@alpha
 ```
 
 Requires Node.js 20+ and git.
+
+### Development setup
+
+```
+git clone https://github.com/vraspar/brain.git
+cd brain && npm install && npm run build && npm link
+```
 
 ## Usage
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,14 +10,12 @@ This guide walks through installing Brain CLI, creating or joining a brain, and 
 ## Install
 
 ```bash
-git clone https://github.com/vraspar/brain.git
-cd brain
-npm install
-npm run build
-npm link
+npm install -g @vraspar/brain@alpha
 ```
 
-After `npm link`, the `brain` command is available globally.
+After install, the `brain` command is available globally.
+
+For development, clone the repo instead: see [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## Option A: Create a new brain
 

--- a/website/index.html
+++ b/website/index.html
@@ -31,8 +31,8 @@
     </p>
 
     <div class="install-block">
-      <code><span class="prompt">$</span> git clone https://github.com/vraspar/brain.git && cd brain && npm install && npm run build && npm link</code>
-      <button class="copy-btn" data-copy="git clone https://github.com/vraspar/brain.git && cd brain && npm install && npm run build && npm link" aria-label="Copy to clipboard">
+      <code><span class="prompt">$</span> npm install -g @vraspar/brain@alpha</code>
+      <button class="copy-btn" data-copy="npm install -g @vraspar/brain@alpha" aria-label="Copy to clipboard">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
       </button>
     </div>
@@ -183,8 +183,7 @@ Found 3 results:
 
       <div class="terminal" aria-label="Installation and setup commands">
         <div><span class="comment"># Install</span></div>
-        <div><span class="prompt">$ </span><span class="command">git clone https://github.com/vraspar/brain.git</span></div>
-        <div><span class="prompt">$ </span><span class="command">cd brain && npm install && npm run build && npm link</span></div>
+        <div><span class="prompt">$ </span><span class="command">npm install -g @vraspar/brain@alpha</span></div>
         <div>&nbsp;</div>
         <div><span class="comment"># Create a brain</span></div>
         <div><span class="prompt">$ </span><span class="command">brain init --name "My Team"</span></div>


### PR DESCRIPTION
npm install is now the primary install method across all docs.

- **README.md** — \
pm install -g @vraspar/brain@alpha\ primary, git clone under 'Development setup'
- **docs/getting-started.md** — npm install, links to CONTRIBUTING for dev setup
- **website/index.html** — hero install block + quick start updated
- **docs/commands.md** — no install references (unchanged)
- **CONTRIBUTING.md** — keeps git clone (unchanged, correct for dev)