### PR TITLE
docs: sync MCP tools (7 → 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `list_entries` MCP tool — agents can list all entries with optional filters (#40)
 - `explore_topic` MCP tool — agents can follow knowledge trails via FTS5 + link traversal (#40)
+- `retract_entry` MCP tool — agents can archive entries (reversible)
 - Partial ID matching in `get_entry` and `update_entry` MCP tools via `resolveEntryId` (#41)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ All commands support `--format json`. Run `brain <command> --help` for flags.
 - **Repo ingest** — import docs from external repos with freshness scoring
 - **Freshness** — entries scored Fresh/Aging/Stale; `brain prune` archives stale ones
 - **Knowledge trails** — auto-linked entries via tag overlap, title similarity, cross-references
-- **MCP server** — 7 tools + 2 resources, works with Claude, Copilot, Cursor, Windsurf
+- **MCP server** — 10 tools + 2 resources, works with Claude, Copilot, Cursor, Windsurf
 - **Read analytics** — per-entry read tracking across CLI and MCP
 - **Auto-detection** — title, type, and tags inferred from content on push
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -714,7 +714,7 @@ brain sync
 
 ## brain serve
 
-Start the MCP server on stdio transport.
+Start the MCP server on stdio transport. Exposes 10 tools and 2 resources.
 
 ```
 brain serve

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -293,6 +293,43 @@ Update an existing entry's fields. Commits changes automatically.
 
 Only provided fields are updated. Updates the `updated` timestamp. Setting status to `"archived"` hides the entry from search, digest, and recommendations.
 
+### list_entries
+
+List entries with optional filters. Useful for agents browsing the knowledge base.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `type` | `"guide"` \| `"skill"` | no | — | Filter by entry type |
+| `tag` | string | no | — | Filter by tag |
+| `author` | string | no | — | Filter by author |
+| `fresh_only` | boolean | no | `false` | Only return fresh entries |
+| `limit` | number | no | `20` | Maximum entries |
+
+### explore_topic
+
+Explore a topic by following knowledge trails — combines FTS5 search with auto-computed entry links.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `topic` | string | yes | — | Topic to explore |
+| `limit` | number | no | `5` | Maximum entries |
+
+Returns entries with their related entries and relationship reasons.
+
+### retract_entry
+
+Archive an entry (reversible). Moves the file to `_archive/`, sets status to `archived`, and rebuilds the index.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `id` | string | yes | — | Entry ID (slug) to archive |
+
 ## Resources
 
 Resources provide ambient context that MCP clients can read without an explicit tool call. Both return `text/markdown` content.

--- a/website/index.html
+++ b/website/index.html
@@ -119,7 +119,7 @@ Found 3 results:
         </div>
         <div class="card">
           <h3>MCP server</h3>
-          <p>7 tools and 2 resources exposed via Model Context Protocol. AI agents can search, read, and publish entries. <code>brain serve</code> starts the server.</p>
+          <p>10 tools and 2 resources exposed via Model Context Protocol. AI agents can search, read, edit, and publish entries. <code>brain serve</code> starts the server.</p>
         </div>
         <div class="card">
           <h3>Repo ingest</h3>
@@ -168,7 +168,7 @@ Found 3 results:
 }</div>
       </div>
 
-      <p class="agent-tools">7 tools: push_knowledge · search_knowledge · whats_new · get_entry · brain_stats · get_recommendations · update_entry<br>2 resources: brain://digest · brain://stats</p>
+      <p class="agent-tools">10 tools: push_knowledge · search_knowledge · whats_new · get_entry · brain_stats · get_recommendations · update_entry · list_entries · explore_topic · retract_entry<br>2 resources: brain://digest · brain://stats</p>
 
       <p class="agent-desc">Your agent can search team knowledge, publish findings, and check what's new.</p>
 


### PR DESCRIPTION
Add 3 new MCP tools to documentation:

- **list_entries** — list/filter entries (type, tag, author, fresh_only, limit)
- **explore_topic** — follow knowledge trails (topic, limit)
- **retract_entry** — archive an entry (id)

Updated: README (tool count), mcp-integration.md (parameter tables), commands.md (serve section), website (tool count + list), CHANGELOG (retract_entry in alpha.3).

Docs consistency: 41/41 passed.