### PR TITLE
fix: wire registerRetractEntry into registerTools

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -37,6 +37,7 @@ export function registerTools(server: McpServer, context: BrainMcpContext): void
   registerUpdateEntry(server, context);
   registerListEntries(server, context);
   registerExploreTopic(server, context);
+  registerRetractEntry(server, context);
 }
 
 function registerPushKnowledge(server: McpServer, context: BrainMcpContext): void {


### PR DESCRIPTION
retract_entry function existed but was never called from registerTools — lost during merge. 1-line fix. 29 MCP tests pass.