### PR TITLE
fix: read version from package.json + bump to alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brain",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brain",
-      "version": "0.1.0-alpha.2",
+      "version": "0.1.0-alpha.3",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vraspar/brain",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "CLI-first knowledge sharing for dev teams",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import { initCommand } from './commands/init.js';
 import { connectCommand } from './commands/connect.js';
@@ -22,12 +25,15 @@ import { openCommand } from './commands/open.js';
 import { editCommand } from './commands/edit.js';
 import { statusCommand } from './commands/status.js';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+
 const program = new Command();
 
 program
   .name('brain')
   .description('CLI-first knowledge sharing for dev teams')
-  .version('0.1.0')
+  .version(pkg.version)
   .option('--format <format>', 'Output format: text or json', 'text')
   .option('-q, --quiet', 'Suppress non-essential output');
 


### PR DESCRIPTION
Replace hardcoded version with dynamic read from package.json. brain --version now always matches the published version. Bumps to 0.1.0-alpha.3.