### PR TITLE
docs: add Obsidian compatibility documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ All commands support `--format json`. Run `brain <command> --help` for flags.
 - **MCP server** — 10 tools + 2 resources, works with Claude, Copilot, Cursor, Windsurf
 - **Read analytics** — per-entry read tracking across CLI and MCP
 - **Auto-detection** — title, type, and tags inferred from content on push
+- **Obsidian compatible** — `brain init --obsidian` creates repo at `~/brain`, doubles as an Obsidian vault
 
 ## MCP setup
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,8 @@
 
 ## Current (v0.3.0)
 
-- 15 CLI commands: `init`, `connect`, `push`, `digest`, `search`, `show`, `list`, `stats`, `retract`, `sync`, `serve`, `ingest`, `prune`, `restore`, `trail`
+- 21 CLI commands: `init`, `connect`, `push`, `digest`, `search`, `show`, `list`, `stats`, `retract`, `sync`, `serve`, `ingest`, `prune`, `restore`, `trail`, `edit`, `open`, `remote`, `sources`, `status`, plus `help`
+- Obsidian compatibility: `brain init --obsidian` creates repo at `~/brain`, usable as an Obsidian vault
 - Repo ingest: `brain ingest` imports docs from remote repos or local directories with freshness scoring at import time
 - Freshness scoring: multiplicative formula (recency base, usage boost, volatility modifier) with Fresh/Aging/Stale labels
 - Knowledge pruning: `brain prune` archives stale entries to `_archive/`, reversible with `brain restore`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,7 +16,7 @@ All commands support these global options:
 Create a new brain hub. Initializes a git repository with the standard directory structure (`guides/`, `skills/`, `_analytics/receipts/`), generates a README, and creates `~/.brain/config.yaml`.
 
 ```
-brain init [--name <name>] [--remote <url>] [--author <name>]
+brain init [--name <name>] [--remote <url>] [--author <name>] [--obsidian]
 ```
 
 | Flag | Required | Description |
@@ -24,6 +24,7 @@ brain init [--name <name>] [--remote <url>] [--author <name>]
 | `--name <name>` | In JSON mode | Brain name. Used in the generated README. If omitted in text mode, triggers interactive prompts. |
 | `--remote <url>` | No | Git remote URL. If provided, adds as `origin` and pushes the initial commit. |
 | `--author <name>` | No | Override the author identity. Default: `git config user.name`. |
+| `--obsidian` | No | Enable Obsidian compatibility. Creates the repo at `~/brain` (visible in Obsidian vault picker) instead of `~/.brain/repo`. |
 
 ### Behavior
 
@@ -50,6 +51,9 @@ brain init
 
 # JSON output (for scripts)
 brain init --name "CI Brain" --format json
+
+# Obsidian-compatible (repo at ~/brain)
+brain init --name "My Brain" --obsidian
 ```
 
 JSON output:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,9 @@ lastSync: "2026-03-23T12:00:00.000Z"
 # ISO 8601 timestamp of last brain digest. Updated by brain digest.
 # Used as the default --since window on the next digest run.
 lastDigest: "2026-03-23T12:00:00.000Z"
+
+# Enable Obsidian compatibility. When true, repo lives at ~/brain instead of ~/.brain/repo.
+obsidian: false
 ```
 
 ### Field reference
@@ -52,6 +55,7 @@ lastDigest: "2026-03-23T12:00:00.000Z"
 | `local` | Yes | string | `init`, `connect` | Absolute path to the local repo. |
 | `author` | Yes | string | `init`, `connect` | Author identity for entries and receipts. |
 | `hubName` | No | string | `init`, `connect` | Human-readable brain name. |
+| `obsidian` | No | boolean | `init --obsidian` | Obsidian compatibility mode. Repo at `~/brain`. |
 | `lastSync` | No | string | `sync`, `init`, `connect` | ISO 8601 timestamp. |
 | `lastDigest` | No | string | `digest` | ISO 8601 timestamp. |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -231,6 +231,18 @@ See entry counts, freshness distribution, and sync state:
 brain status
 ```
 
+## Using with Obsidian
+
+Brain repos are plain markdown in directories — they double as Obsidian vaults.
+
+```bash
+brain init --name "My Brain" --obsidian
+```
+
+This creates the repo at `~/brain` instead of `~/.brain/repo`, making it visible in Obsidian's vault picker. Open `~/brain` as a vault in Obsidian to browse and edit entries with a visual editor alongside the CLI.
+
+Entries in `guides/` and `skills/` are standard markdown with YAML frontmatter — Obsidian renders them natively. After editing in Obsidian, run `brain sync` to commit and push changes.
+
 ## Next steps
 
 - [Full CLI reference](commands.md) — all commands, flags, and edge cases


### PR DESCRIPTION
Docs for the --obsidian flag. Updated commands.md, configuration.md, getting-started.md, README.md, ROADMAP.md. Wait for implementation PR before merging.