### PR TITLE
fix: correct Obsidian docs — .obsidian/ not ~/brain path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All commands support `--format json`. Run `brain <command> --help` for flags.
 - **MCP server** — 10 tools + 2 resources, works with Claude, Copilot, Cursor, Windsurf
 - **Read analytics** — per-entry read tracking across CLI and MCP
 - **Auto-detection** — title, type, and tags inferred from content on push
-- **Obsidian compatible** — `brain init --obsidian` creates repo at `~/brain`, doubles as an Obsidian vault
+- **Obsidian compatible** — `brain init --obsidian` creates `.obsidian/` config and adds wikilink footers to entries
 
 ## MCP setup
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Current (v0.3.0)
 
 - 21 CLI commands: `init`, `connect`, `push`, `digest`, `search`, `show`, `list`, `stats`, `retract`, `sync`, `serve`, `ingest`, `prune`, `restore`, `trail`, `edit`, `open`, `remote`, `sources`, `status`, plus `help`
-- Obsidian compatibility: `brain init --obsidian` creates repo at `~/brain`, usable as an Obsidian vault
+- Obsidian compatibility: `brain init --obsidian` creates `.obsidian/` config and enables wikilink footers
 - Repo ingest: `brain ingest` imports docs from remote repos or local directories with freshness scoring at import time
 - Freshness scoring: multiplicative formula (recency base, usage boost, volatility modifier) with Fresh/Aging/Stale labels
 - Knowledge pruning: `brain prune` archives stale entries to `_archive/`, reversible with `brain restore`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,7 +24,7 @@ brain init [--name <name>] [--remote <url>] [--author <name>] [--obsidian]
 | `--name <name>` | In JSON mode | Brain name. Used in the generated README. If omitted in text mode, triggers interactive prompts. |
 | `--remote <url>` | No | Git remote URL. If provided, adds as `origin` and pushes the initial commit. |
 | `--author <name>` | No | Override the author identity. Default: `git config user.name`. |
-| `--obsidian` | No | Enable Obsidian compatibility. Creates the repo at `~/brain` (visible in Obsidian vault picker) instead of `~/.brain/repo`. |
+| `--obsidian` | No | Enable Obsidian compatibility. Creates `.obsidian/` config in the repo and enables wikilink footers in entries. |
 
 ### Behavior
 
@@ -52,7 +52,7 @@ brain init
 # JSON output (for scripts)
 brain init --name "CI Brain" --format json
 
-# Obsidian-compatible (repo at ~/brain)
+# Obsidian-compatible (adds .obsidian/ and wikilinks)
 brain init --name "My Brain" --obsidian
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ lastSync: "2026-03-23T12:00:00.000Z"
 # Used as the default --since window on the next digest run.
 lastDigest: "2026-03-23T12:00:00.000Z"
 
-# Enable Obsidian compatibility. When true, repo lives at ~/brain instead of ~/.brain/repo.
+# Enable Obsidian compatibility. Creates .obsidian/ config and wikilink footers.
 obsidian: false
 ```
 
@@ -55,7 +55,7 @@ obsidian: false
 | `local` | Yes | string | `init`, `connect` | Absolute path to the local repo. |
 | `author` | Yes | string | `init`, `connect` | Author identity for entries and receipts. |
 | `hubName` | No | string | `init`, `connect` | Human-readable brain name. |
-| `obsidian` | No | boolean | `init --obsidian` | Obsidian compatibility mode. Repo at `~/brain`. |
+| `obsidian` | No | boolean | `init --obsidian` | Obsidian compatibility. Creates `.obsidian/` config and wikilink footers. |
 | `lastSync` | No | string | `sync`, `init`, `connect` | ISO 8601 timestamp. |
 | `lastDigest` | No | string | `digest` | ISO 8601 timestamp. |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -239,7 +239,7 @@ Brain repos are plain markdown in directories — they double as Obsidian vaults
 brain init --name "My Brain" --obsidian
 ```
 
-This creates the repo at `~/brain` instead of `~/.brain/repo`, making it visible in Obsidian's vault picker. Open `~/brain` as a vault in Obsidian to browse and edit entries with a visual editor alongside the CLI.
+This creates `.obsidian/` config in the repo so it's recognized as an Obsidian vault. Open `~/.brain/repo` (or wherever your brain lives) as a vault in Obsidian to browse and edit entries with a visual editor alongside the CLI.
 
 Entries in `guides/` and `skills/` are standard markdown with YAML frontmatter — Obsidian renders them natively. After editing in Obsidian, run `brain sync` to commit and push changes.
 


### PR DESCRIPTION
Fixes 7 inaccurate references claiming --obsidian changes repo path to ~/brain. The flag actually creates .obsidian/ config and enables wikilink footers. Fixed across README, ROADMAP, commands.md, configuration.md, getting-started.md.