### PR TITLE
fix: wire updateObsidianLinks into sync/push/ingest/connect

### DIFF
--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { joinBrain } from '../core/repo.js';
 import { scanEntries } from '../core/entry.js';
 import { createIndex, rebuildIndex, getDbPath } from '../core/index-db.js';
+import { maybeUpdateObsidianLinks } from '../core/obsidian.js';
 
 /**
  * Shared handler for both `brain connect` and `brain join`.
@@ -32,6 +33,7 @@ export async function handleConnect(
     const db = createIndex(getDbPath());
     try {
       rebuildIndex(db, entries);
+      maybeUpdateObsidianLinks(config, db);
     } finally {
       db.close();
     }

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -5,8 +5,10 @@ import { runIngest, extractRepoName } from '../core/ingest.js';
 import { scanEntries } from '../core/entry.js';
 import { createIndex, rebuildIndex, getDbPath, updateFreshnessScores } from '../core/index-db.js';
 import { commitAndPush } from '../utils/git.js';
+import { recordReceipt } from '../core/receipts.js';
 import { upsertSource } from '../core/sources.js';
 import { buildUsageStatsMap } from '../core/freshness-stats.js';
+import { maybeUpdateObsidianLinks } from '../core/obsidian.js';
 import type { EntryType, IngestCandidate } from '../types.js';
 
 function freshnessIcon(freshness: string): string {
@@ -130,6 +132,7 @@ export const ingestCommand = new Command('ingest')
         if (result.imported.length > 0 && config.remote) {
           const entries = await scanEntries(config.local);
           rebuildIndex(db, entries);
+          maybeUpdateObsidianLinks(config, db);
 
           // Compute freshness scores for ingested entries
           const statsMap = buildUsageStatsMap(config.local, '30d');
@@ -150,6 +153,7 @@ export const ingestCommand = new Command('ingest')
           // Local-only: rebuild index
           const entries = await scanEntries(config.local);
           rebuildIndex(db, entries);
+          maybeUpdateObsidianLinks(config, db);
 
           // Compute freshness scores
           const statsMap = buildUsageStatsMap(config.local, '30d');

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -15,6 +15,7 @@ import { createIndex, rebuildIndex, getDbPath } from '../core/index-db.js';
 import { commitAndPush } from '../utils/git.js';
 import { recordReceipt } from '../core/receipts.js';
 import { extractTags } from '../utils/tags.js';
+import { maybeUpdateObsidianLinks } from '../core/obsidian.js';
 import type { EntryType } from '../types.js';
 
 /**
@@ -238,6 +239,7 @@ export const pushCommand = new Command('push')
       const db = createIndex(getDbPath());
       try {
         rebuildIndex(db, entries);
+        maybeUpdateObsidianLinks(config, db);
       } finally {
         db.close();
       }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -5,6 +5,7 @@ import { syncBrain } from '../core/repo.js';
 import { scanEntries } from '../core/entry.js';
 import { createIndex, getDbPath, rebuildIndex, updateFreshnessScores } from '../core/index-db.js';
 import { buildUsageStatsMap } from '../core/freshness-stats.js';
+import { maybeUpdateObsidianLinks } from '../core/obsidian.js';
 
 export const syncCommand = new Command('sync')
   .description('Pull latest changes and rebuild the index')
@@ -21,6 +22,7 @@ export const syncCommand = new Command('sync')
         const db = createIndex(getDbPath());
         try {
           rebuildIndex(db, entries);
+          maybeUpdateObsidianLinks(config, db);
           const statsMap = buildUsageStatsMap(config.local, '30d');
           updateFreshnessScores(db, statsMap);
         } finally {
@@ -50,6 +52,7 @@ export const syncCommand = new Command('sync')
       const db = createIndex(getDbPath());
       try {
         rebuildIndex(db, entries);
+        maybeUpdateObsidianLinks(config, db);
 
         // Update freshness scores after rebuilding index
         const statsMap = buildUsageStatsMap(config.local, '30d');

--- a/src/core/obsidian.ts
+++ b/src/core/obsidian.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type Database from 'better-sqlite3';
 import matter from 'gray-matter';
+import type { BrainConfig } from '../types.js';
 import { getAllEntries } from './index-db.js';
 import { getRelatedEntries } from './links.js';
 
@@ -92,4 +93,17 @@ export function removeObsidianLinks(repoPath: string): void {
       fs.writeFileSync(fullPath, newRaw, 'utf-8');
     }
   }
+}
+
+/**
+ * Convenience: update Obsidian wikilinks if obsidian mode is enabled.
+ * Call after rebuildIndex in any command that modifies entries.
+ */
+export function maybeUpdateObsidianLinks(
+  config: BrainConfig,
+  db: Database.Database,
+): void {
+  if (!config.obsidian) return;
+  ensureObsidianConfig(config.local);
+  updateObsidianLinks(db, config.local);
 }


### PR DESCRIPTION
Calls maybeUpdateObsidianLinks(config, db) after rebuildIndex in sync, push, ingest, connect. Only runs when obsidian: true. Ensures wikilink footers stay current.