### PR TITLE
fix: ingest freshness baseline + source-tag slug prefix

### DIFF
--- a/src/core/ingest.ts
+++ b/src/core/ingest.ts
@@ -275,21 +275,44 @@ export async function importCandidates(
       continue;
     }
 
-    // Generate slug and check for pre-existing entries in the brain
+    // Generate slug from source path for uniqueness.
+    // Include repo name + parent dir + filename to avoid collisions.
+    // Example: onnxruntime-genai/cmake/external/opencv/README.md → onnxruntime-genai-opencv-readme
     let slug: string;
     try {
-      const baseSlug = generateEntryId(candidate.title);
+      const pathParts = candidate.sourcePath.replace(/\\/g, '/').split('/');
+      const filename = pathParts[pathParts.length - 1].replace(/\.md$/i, '');
+      const parentDir = pathParts.length >= 2 ? pathParts[pathParts.length - 2] : '';
 
-      // If the base slug exists in the DB (not just in this batch),
-      // skip unless --overwrite is set
-      const preExisting = getEntryById(db, baseSlug);
-      if (preExisting && !options.overwrite) {
-        skipped.push({ path: candidate.sourcePath, reason: `duplicate slug "${baseSlug}"` });
-        continue;
+      // For generic filenames, include parent dir in slug
+      const genericNames = new Set(['readme', 'index', 'overview', 'introduction', 'getting-started']);
+      let slugBase: string;
+      if (genericNames.has(filename.toLowerCase()) && parentDir) {
+        // Include repo name prefix if source-tag is set
+        const repoPrefix = repoName ? `${repoName}-` : '';
+        slugBase = `${repoPrefix}${parentDir}-${filename}`;
+      } else {
+        slugBase = candidate.title;
       }
 
-      // Generate unique slug handling intra-batch collisions
-      slug = generateUniqueEntryId(candidate.title, existingIds);
+      const baseSlug = generateEntryId(slugBase);
+
+      // If slug collides with existing entry, append numeric suffix
+      if (existingIds.has(baseSlug)) {
+        if (!options.overwrite) {
+          let counter = 2;
+          let uniqueSlug = `${baseSlug}-${counter}`;
+          while (existingIds.has(uniqueSlug)) {
+            counter++;
+            uniqueSlug = `${baseSlug}-${counter}`;
+          }
+          slug = uniqueSlug;
+        } else {
+          slug = baseSlug;
+        }
+      } else {
+        slug = baseSlug;
+      }
     } catch {
       skipped.push({ path: candidate.sourcePath, reason: 'cannot generate slug from title' });
       continue;

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -131,23 +131,12 @@ describe('matchGlob', () => {
 // --- computeImportFreshness ---
 
 describe('computeImportFreshness', () => {
-  it('returns fresh for recent dates', () => {
-    const recent = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days ago
+  it('always returns fresh — ingested content is new to this brain', () => {
+    const recent = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const old = new Date(Date.now() - 120 * 24 * 60 * 60 * 1000);
     expect(computeImportFreshness(recent)).toBe('fresh');
-  });
-
-  it('returns aging for 30-90 day old dates', () => {
-    const aging = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000); // 60 days ago
-    expect(computeImportFreshness(aging)).toBe('aging');
-  });
-
-  it('returns stale for 90+ day old dates', () => {
-    const stale = new Date(Date.now() - 120 * 24 * 60 * 60 * 1000); // 120 days ago
-    expect(computeImportFreshness(stale)).toBe('stale');
-  });
-
-  it('returns aging for undefined date (conservative default)', () => {
-    expect(computeImportFreshness(undefined)).toBe('aging');
+    expect(computeImportFreshness(old)).toBe('fresh');
+    expect(computeImportFreshness(undefined)).toBe('fresh');
   });
 });
 
@@ -393,7 +382,7 @@ describe('importCandidates', () => {
     }
   });
 
-  it('skips duplicates by default', async () => {
+  it('creates unique slug on collision instead of skipping', async () => {
     const db = createIndex(dbPath);
     try {
       // Pre-existing entry
@@ -422,9 +411,8 @@ describe('importCandidates', () => {
         author: 'testuser',
       });
 
-      expect(result.imported).toHaveLength(0);
-      expect(result.skipped).toHaveLength(1);
-      expect(result.skipped[0].reason).toContain('duplicate');
+      // Should import with a unique slug (not skip)
+      expect(result.imported).toHaveLength(1);
     } finally {
       db.close();
     }


### PR DESCRIPTION
1. Ingested content uses ingest date for freshness (starts fresh, not stale)
2. Generic filenames prefixed with repo name for cross-repo uniqueness
3. Never skips on collision — appends numeric suffix

No --admin.