### PR TITLE
fix: ingested entries enter as active, store source date as source_last_modified

### DIFF
--- a/src/core/entry.ts
+++ b/src/core/entry.ts
@@ -57,6 +57,7 @@ export function parseEntry(filePath: string, content: string): Entry {
     source_repo: data['source_repo'] ? String(data['source_repo']) : undefined,
     source_path: data['source_path'] ? String(data['source_path']) : undefined,
     source_content_hash: data['source_content_hash'] ? String(data['source_content_hash']) : undefined,
+    source_last_modified: data['source_last_modified'] ? String(data['source_last_modified']) : undefined,
   };
 }
 
@@ -85,6 +86,7 @@ export function serializeEntry(entry: Omit<Entry, 'id' | 'filePath'>): string {
   if (entry.source_repo) frontmatter['source_repo'] = entry.source_repo;
   if (entry.source_path) frontmatter['source_path'] = entry.source_path;
   if (entry.source_content_hash) frontmatter['source_content_hash'] = entry.source_content_hash;
+  if (entry.source_last_modified) frontmatter['source_last_modified'] = entry.source_last_modified;
 
   return matter.stringify(entry.content, frontmatter);
 }

--- a/src/core/ingest.ts
+++ b/src/core/ingest.ts
@@ -300,9 +300,6 @@ export async function importCandidates(
       continue;
     }
 
-    // Determine entry status based on freshness
-    const status = candidate.freshness === 'stale' ? 'stale' as const : 'active' as const;
-
     // Build tags
     const tags = [...candidate.tags];
     if (options.sourceTag) {
@@ -312,6 +309,7 @@ export async function importCandidates(
       }
     }
 
+    // Ingested entries are new to this brain — always active, use ingest date
     const entry: Entry = createEntry({
       title: candidate.title,
       type: options.type ?? 'guide',
@@ -322,21 +320,20 @@ export async function importCandidates(
 
     const dirName = (options.type ?? 'guide') === 'skill' ? 'skills' : 'guides';
 
-    // Override status, ID (for collision handling), and source metadata
+    // Override ID (for collision handling) and add source metadata
     const entryWithMeta: Entry = {
       ...entry,
       id: slug,
       filePath: `${dirName}/${slug}.md`,
-      status,
+      status: 'active',
       source_repo: repoName,
       source_path: candidate.sourcePath,
       source_content_hash: crypto.createHash('sha256').update(candidate.content).digest('hex'),
+      source_last_modified: candidate.sourceUpdated,
     };
 
-    // Set dates from source if available
-    if (candidate.sourceUpdated) {
-      entryWithMeta.updated = candidate.sourceUpdated;
-    }
+    // created/updated use ingest date (from createEntry) — entry is new to this brain
+    // source_last_modified preserves the original git date for reference
 
     await writeEntry(brainRepoPath, entryWithMeta);
     existingIds.add(entryWithMeta.id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface EntryFrontmatter {
   source_repo?: string;
   source_path?: string;
   source_content_hash?: string;
+  source_last_modified?: string; // ISO 8601, original git date from source repo
   archived_at?: string; // ISO 8601
   archived_reason?: string;
 }

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -465,7 +465,7 @@ describe('importCandidates', () => {
     }
   });
 
-  it('sets status to stale for stale freshness', async () => {
+  it('imports all entries as active regardless of source freshness', async () => {
     const db = createIndex(dbPath);
     try {
       const candidates: IngestCandidate[] = [
@@ -475,6 +475,7 @@ describe('importCandidates', () => {
           tags: [],
           content: 'Very old content.',
           freshness: 'stale',
+          sourceUpdated: '2024-01-01T00:00:00Z',
         },
       ];
 
@@ -486,7 +487,8 @@ describe('importCandidates', () => {
       const entries = await scanEntries(repoDir);
       const imported = entries.find(e => e.title === 'Old Migration Guide');
       expect(imported).toBeDefined();
-      expect(imported!.status).toBe('stale');
+      expect(imported!.status).toBe('active');
+      expect(imported!.source_last_modified).toBe('2024-01-01T00:00:00Z');
     } finally {
       db.close();
     }


### PR DESCRIPTION
Imported docs are new to this brain — enter as active with ingest date.

- status: always active (not stale based on source age)
- created/updated: ingest date (from createEntry)
- source_last_modified: original git date preserved for reference
- Added to types, parser, serializer

48 ingest tests pass.