### PR TITLE
fix: hide ID column by default, add --show-id flag

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -14,6 +14,7 @@ interface ListOptions {
   unread?: boolean;
   stale?: boolean;
   fresh?: boolean;
+  showId?: boolean;
 }
 
 export const listCommand = new Command('list')
@@ -25,6 +26,7 @@ export const listCommand = new Command('list')
   .option('--unread', 'Show only entries you have not read')
   .option('--stale', 'Show only stale entries (🔴)')
   .option('--fresh', 'Show only fresh entries (🟢)')
+  .option('--show-id', 'Show entry ID column')
   .action(async (options: ListOptions) => {
     const format = listCommand.parent?.opts().format ?? 'text';
 
@@ -113,7 +115,7 @@ export const listCommand = new Command('list')
         db.close();
       }
 
-      console.log(formatSearchResults(entries, { format, freshness: freshnessMap }));
+      console.log(formatSearchResults(entries, { format, freshness: freshnessMap, showId: options.showId }));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (format === 'json') {

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -49,7 +49,8 @@ export const searchCommand = new Command('search')
   .option('--limit <n>', 'Maximum results to return', '20')
   .option('--no-preview', 'Hide content preview snippets')
   .option('--no-interactive', 'Skip the selection prompt')
-  .action(async (query: string, options: { limit: string; preview: boolean; interactive: boolean }) => {
+  .option('--show-id', 'Show entry ID column')
+  .action(async (query: string, options: { limit: string; preview: boolean; interactive: boolean; showId?: boolean }) => {
     const format = searchCommand.parent?.opts().format ?? 'text';
 
     try {
@@ -69,7 +70,7 @@ export const searchCommand = new Command('search')
           ? new Map(results.map((r) => [r.entry.id, r.snippet]))
           : undefined;
 
-        console.log(formatSearchResults(entries, { format, snippets }));
+        console.log(formatSearchResults(entries, { format, snippets, showId: options.showId }));
 
         // Interactive selection (text mode only, TTY only)
         if (format !== 'json' && options.interactive && entries.length > 0) {

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -9,10 +9,16 @@ export interface FormatOptions {
 }
 
 const MAX_TITLE_LENGTH = 40;
+const MAX_ID_LENGTH = 28;
 
 function truncateTitle(title: string, maxLength = MAX_TITLE_LENGTH): string {
   if (title.length <= maxLength) return title;
   return title.slice(0, maxLength - 3) + '...';
+}
+
+function truncateId(id: string, maxLength = MAX_ID_LENGTH): string {
+  if (id.length <= maxLength) return id;
+  return id.slice(0, maxLength - 2) + '..';
 }
 
 export function formatEntry(entry: Entry, options: FormatOptions = {}): string {
@@ -137,6 +143,7 @@ export function formatSearchResults(
   options: FormatOptions & {
     snippets?: Map<string, string>;
     freshness?: Map<string, FreshnessLabel>;
+    showId?: boolean;
   } = {},
 ): string {
   if (options.format === 'json') {
@@ -157,17 +164,20 @@ export function formatSearchResults(
 
   const showPreview = options.snippets && options.snippets.size > 0;
   const showFreshness = options.freshness && options.freshness.size > 0;
+  const showId = options.showId ?? false;
 
-  const head = showPreview
-    ? ['ID', 'Title', 'Author', 'Type', 'Tags', 'Preview']
-    : showFreshness
-      ? ['ID', 'Title', 'Author', 'Type', 'Freshness', 'Tags']
-      : ['ID', 'Title', 'Author', 'Type', 'Tags', 'Status'];
+  const head: string[] = [];
+  if (showId) head.push('ID');
+  head.push('Title', 'Author', 'Type');
+  if (showFreshness) head.push('Freshness');
+  head.push('Tags');
+  if (showPreview) head.push('Preview');
+  if (!showFreshness && !showPreview) head.push('Status');
 
   const table = new Table({
     head,
     style: { head: ['cyan'] },
-    ...(showPreview ? { colWidths: [null, null, null, null, 40] } : {}),
+    ...(showPreview ? { colWidths: [null, null, null, null, null, 40] } : {}),
   });
 
   for (const entry of entries) {
@@ -178,37 +188,29 @@ export function formatSearchResults(
           ? chalk.yellow
           : chalk.gray;
 
+    const row: string[] = [];
+    if (showId) row.push(chalk.dim(truncateId(entry.id)));
+    row.push(truncateTitle(entry.title));
+    row.push(entry.author);
+    row.push(entry.type);
+
+    if (showFreshness) {
+      const label = options.freshness!.get(entry.id);
+      row.push(label ? freshnessIndicator(label) : statusColor(entry.status));
+    }
+
+    row.push(entry.tags.slice(0, 3).join(', '));
+
     if (showPreview) {
       const snippet = options.snippets!.get(entry.id) ?? '';
-      const cleanSnippet = snippet.replace(/[«»]/g, '').slice(0, 60);
-      table.push([
-        chalk.dim(entry.id),
-        truncateTitle(entry.title),
-        entry.author,
-        entry.type,
-        entry.tags.slice(0, 3).join(', '),
-        chalk.dim(cleanSnippet),
-      ]);
-    } else if (showFreshness) {
-      const label = options.freshness!.get(entry.id);
-      table.push([
-        chalk.dim(entry.id),
-        truncateTitle(entry.title),
-        entry.author,
-        entry.type,
-        label ? freshnessIndicator(label) : statusColor(entry.status),
-        entry.tags.slice(0, 3).join(', '),
-      ]);
-    } else {
-      table.push([
-        chalk.dim(entry.id),
-        truncateTitle(entry.title),
-        entry.author,
-        entry.type,
-        entry.tags.slice(0, 3).join(', '),
-        statusColor(entry.status),
-      ]);
+      row.push(chalk.dim(snippet.replace(/[«»]/g, '').slice(0, 60)));
     }
+
+    if (!showFreshness && !showPreview) {
+      row.push(statusColor(entry.status));
+    }
+
+    table.push(row);
   }
 
   return `${chalk.bold(`Found ${entries.length} result${entries.length === 1 ? '' : 's'}:`)}\n${table.toString()}`;


### PR DESCRIPTION
Fixes broken table output with long IDs.

- ID column hidden by default (was pushing tables off screen)
- \--show-id\ flag on list and search to show truncated IDs (28 chars)
- Freshness label no longer truncated
- Table builder refactored to conditional row construction

27 tests pass.