### PR TITLE
fix: always show truncated ID column in list/search

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -14,7 +14,6 @@ interface ListOptions {
   unread?: boolean;
   stale?: boolean;
   fresh?: boolean;
-  showId?: boolean;
 }
 
 export const listCommand = new Command('list')
@@ -26,7 +25,6 @@ export const listCommand = new Command('list')
   .option('--unread', 'Show only entries you have not read')
   .option('--stale', 'Show only stale entries (🔴)')
   .option('--fresh', 'Show only fresh entries (🟢)')
-  .option('--show-id', 'Show entry ID column')
   .action(async (options: ListOptions) => {
     const format = listCommand.parent?.opts().format ?? 'text';
 
@@ -115,7 +113,7 @@ export const listCommand = new Command('list')
         db.close();
       }
 
-      console.log(formatSearchResults(entries, { format, freshness: freshnessMap, showId: options.showId }));
+      console.log(formatSearchResults(entries, { format, freshness: freshnessMap }));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (format === 'json') {

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -49,8 +49,7 @@ export const searchCommand = new Command('search')
   .option('--limit <n>', 'Maximum results to return', '20')
   .option('--no-preview', 'Hide content preview snippets')
   .option('--no-interactive', 'Skip the selection prompt')
-  .option('--show-id', 'Show entry ID column')
-  .action(async (query: string, options: { limit: string; preview: boolean; interactive: boolean; showId?: boolean }) => {
+  .action(async (query: string, options: { limit: string; preview: boolean; interactive: boolean }) => {
     const format = searchCommand.parent?.opts().format ?? 'text';
 
     try {
@@ -70,7 +69,7 @@ export const searchCommand = new Command('search')
           ? new Map(results.map((r) => [r.entry.id, r.snippet]))
           : undefined;
 
-        console.log(formatSearchResults(entries, { format, snippets, showId: options.showId }));
+        console.log(formatSearchResults(entries, { format, snippets }));
 
         // Interactive selection (text mode only, TTY only)
         if (format !== 'json' && options.interactive && entries.length > 0) {

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -164,7 +164,7 @@ export function formatSearchResults(
 
   const showPreview = options.snippets && options.snippets.size > 0;
   const showFreshness = options.freshness && options.freshness.size > 0;
-  const showId = options.showId ?? false;
+  const showId = options.showId ?? true;
 
   const head: string[] = [];
   if (showId) head.push('ID');


### PR DESCRIPTION
ID always visible (truncated to 28 chars), removed --show-id flag. 27 tests pass.